### PR TITLE
Implement user registration with admin approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ This repository contains a Streamlit based application for logistics companies. 
    ```
    The main page displays a horizontal menu for modules such as shipments, trucks, trailers, groups, drivers, clients, employees, planning and updates.
 
-## Planned authentication
+## Naudojimas
 
-Authentication has not been implemented yet. A simple login system is planned so that only authorized employees will be able to view and modify data once the feature is added.
+Paleidus programą veikia prisijungimo sistema. Pirmą kartą duomenų bazėje automatiškai sukuriamas naudotojas **admin** su slaptažodžiu **admin**. Prisijungus šiuo vartotoju galima patvirtinti kitų naudotojų registracijas.
+
+Prisijungimo formoje galima pasirinkti „Registruotis“ ir pateikti naujo vartotojo paraišką. Nauji naudotojai įrašomi su neaktyviu statusu ir negali prisijungti, kol administratorius jų nepatvirtins. Administratorius meniu skiltyje „Registracijos“ mato laukiančius vartotojus ir gali juos patvirtinti arba pašalinti.

--- a/db.py
+++ b/db.py
@@ -131,9 +131,17 @@ def init_db(db_path: str = "main.db"):
         CREATE TABLE IF NOT EXISTS users (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             username TEXT UNIQUE,
-            password_hash TEXT
+            password_hash TEXT,
+            aktyvus INTEGER DEFAULT 0
         )
     """)
+
+    # If the table existed before, ensure the 'aktyvus' column is present
+    c.execute("PRAGMA table_info(users)")
+    existing_cols = [row[1] for row in c.fetchall()]
+    if "aktyvus" not in existing_cols:
+        c.execute("ALTER TABLE users ADD COLUMN aktyvus INTEGER DEFAULT 0")
+        conn.commit()
 
     c.execute("""
         CREATE TABLE IF NOT EXISTS roles (
@@ -161,7 +169,7 @@ def init_db(db_path: str = "main.db"):
         import hashlib
         admin_hash = hashlib.sha256('admin'.encode()).hexdigest()
         c.execute(
-            "INSERT INTO users (username, password_hash) VALUES (?, ?)",
+            "INSERT INTO users (username, password_hash, aktyvus) VALUES (?, ?, 1)",
             ('admin', admin_hash)
         )
         conn.commit()

--- a/main.py
+++ b/main.py
@@ -26,6 +26,7 @@ from modules import (
     vairuotojai,
     klientai,
     darbuotojai,
+    user_admin,
     planavimas,
     update,
     login,
@@ -46,12 +47,14 @@ module_functions = {
     "Vairuotojai": vairuotojai.show,
     "Klientai": klientai.show,
     "Darbuotojai": darbuotojai.show,
+    "Registracijos": user_admin.show,
     "Planavimas": planavimas.show,
     "Update": update.show,
 }
 
 MODULE_ROLES = {
     "Darbuotojai": ["admin"],
+    "Registracijos": ["admin"],
     "Update": ["admin"],
 }
 

--- a/modules/login.py
+++ b/modules/login.py
@@ -1,13 +1,18 @@
 import streamlit as st
 import hashlib
 
+from . import register
+
 
 def hash_password(password: str) -> str:
     return hashlib.sha256(password.encode()).hexdigest()
 
 
 def verify_user(conn, c, username: str, password: str):
-    c.execute("SELECT id, password_hash FROM users WHERE username = ?", (username,))
+    c.execute(
+        "SELECT id, password_hash FROM users WHERE username = ? AND aktyvus = 1",
+        (username,)
+    )
     row = c.fetchone()
     if row and row[1] == hash_password(password):
         return row[0]
@@ -37,6 +42,13 @@ def show(conn, c):
             st.session_state.clear()
             st.experimental_rerun()
     else:
+        if st.session_state.get("show_register"):
+            register.show(conn, c)
+            if st.sidebar.button("Grįžti"):
+                st.session_state.show_register = False
+                st.experimental_rerun()
+            return
+
         st.sidebar.subheader("Prisijungimas")
         username = st.sidebar.text_input("Vartotojas")
         password = st.sidebar.text_input("Slaptažodis", type="password")
@@ -48,4 +60,7 @@ def show(conn, c):
                 st.experimental_rerun()
             else:
                 st.sidebar.error("Neteisingi prisijungimo duomenys")
+        if st.sidebar.button("Registruotis"):
+            st.session_state.show_register = True
+            st.experimental_rerun()
 

--- a/modules/register.py
+++ b/modules/register.py
@@ -1,0 +1,24 @@
+import streamlit as st
+
+from .login import hash_password
+
+
+def show(conn, c):
+    st.subheader("Registracija")
+    username = st.text_input("Vartotojo vardas")
+    password = st.text_input("Slaptažodis", type="password")
+
+    if st.button("Pateikti paraišką"):
+        if not username or not password:
+            st.error("Įveskite vartotojo vardą ir slaptažodį")
+        else:
+            c.execute("SELECT 1 FROM users WHERE username = ?", (username,))
+            if c.fetchone():
+                st.error("Toks vartotojas jau egzistuoja")
+            else:
+                c.execute(
+                    "INSERT INTO users (username, password_hash, aktyvus) VALUES (?, ?, 0)",
+                    (username, hash_password(password)),
+                )
+                conn.commit()
+                st.success("Registracija pateikta. Palaukite administratoriaus patvirtinimo.")

--- a/modules/user_admin.py
+++ b/modules/user_admin.py
@@ -1,0 +1,23 @@
+import streamlit as st
+import pandas as pd
+
+
+def show(conn, c):
+    st.title("Naudotojų patvirtinimas")
+    df = pd.read_sql_query("SELECT id, username FROM users WHERE aktyvus = 0", conn)
+
+    if df.empty:
+        st.info("Nėra laukiančių vartotojų")
+        return
+
+    for _, row in df.iterrows():
+        cols = st.columns([3, 1, 1])
+        cols[0].write(row['username'])
+        if cols[1].button("Patvirtinti", key=f"approve_{row['id']}"):
+            c.execute("UPDATE users SET aktyvus = 1 WHERE id = ?", (row['id'],))
+            conn.commit()
+            st.experimental_rerun()
+        if cols[2].button("Šalinti", key=f"delete_{row['id']}"):
+            c.execute("DELETE FROM users WHERE id = ?", (row['id'],))
+            conn.commit()
+            st.experimental_rerun()


### PR DESCRIPTION
## Summary
- allow `users` to have an `aktyvus` flag
- add registration form and admin approval interface
- update login to respect `aktyvus` and offer registration
- expose user approval for admins in the main menu
- document login/registration process

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d389e64248324a2a96bd10db827e3