### PR TITLE
Refactor auth utilities

### DIFF
--- a/modules/auth_utils.py
+++ b/modules/auth_utils.py
@@ -1,0 +1,6 @@
+import hashlib
+
+
+def hash_password(password: str) -> str:
+    """Return SHA-256 hash of the given password."""
+    return hashlib.sha256(password.encode()).hexdigest()

--- a/modules/login.py
+++ b/modules/login.py
@@ -1,12 +1,6 @@
 import streamlit as st
-import hashlib
 
-from . import register
-
-
-def hash_password(password: str) -> str:
-    return hashlib.sha256(password.encode()).hexdigest()
-
+from .auth_utils import hash_password
 
 def verify_user(conn, c, username: str, password: str):
     c.execute(
@@ -43,6 +37,7 @@ def show(conn, c):
             st.experimental_rerun()
     else:
         if st.session_state.get("show_register"):
+            from . import register
             register.show(conn, c)
             if st.sidebar.button("Grįžti"):
                 st.session_state.show_register = False

--- a/modules/register.py
+++ b/modules/register.py
@@ -1,6 +1,6 @@
 import streamlit as st
 
-from .login import hash_password
+from .auth_utils import hash_password
 
 
 def show(conn, c):


### PR DESCRIPTION
## Summary
- move `hash_password` to new `auth_utils` module
- import `hash_password` from `auth_utils` in login and register
- lazy import register module inside `login.show`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d3fc1d3e48324932d8aa42cc4b92b