### PR TITLE
Fix logout rerun crash

### DIFF
--- a/modules/login.py
+++ b/modules/login.py
@@ -33,7 +33,9 @@ def show(conn, c):
     if "user_id" in st.session_state:
         st.sidebar.success(f"Prisijungta kaip {st.session_state.username}")
         if st.sidebar.button("Atsijungti"):
-            st.session_state.clear()
+            # Avoid Streamlit bug when using `clear()` directly
+            for key in list(st.session_state.keys()):
+                del st.session_state[key]
             st.experimental_rerun()
     else:
         if st.session_state.get("show_register"):


### PR DESCRIPTION
## Summary
- avoid Streamlit crash on logout by clearing session state keys manually

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685d4317ea688324bd6dac6fc8cc0959