### PR TITLE
Refactor rerun logic

### DIFF
--- a/modules/login.py
+++ b/modules/login.py
@@ -1,5 +1,12 @@
 import streamlit as st
 
+
+def rerun():
+    if hasattr(st, "rerun"):
+        st.rerun()
+    else:
+        st.experimental_rerun()
+
 from .auth_utils import hash_password
 
 def verify_user(conn, c, username: str, password: str):
@@ -36,14 +43,14 @@ def show(conn, c):
             # Avoid Streamlit bug when using `clear()` directly
             for key in list(st.session_state.keys()):
                 del st.session_state[key]
-            st.experimental_rerun()
+            rerun()
     else:
         if st.session_state.get("show_register"):
             from . import register
             register.show(conn, c)
             if st.sidebar.button("Grįžti"):
                 st.session_state.show_register = False
-                st.experimental_rerun()
+                rerun()
             return
 
         st.sidebar.subheader("Prisijungimas")
@@ -54,10 +61,10 @@ def show(conn, c):
             if user_id:
                 st.session_state.user_id = user_id
                 st.session_state.username = username
-                st.experimental_rerun()
+                rerun()
             else:
                 st.sidebar.error("Neteisingi prisijungimo duomenys")
         if st.sidebar.button("Registruotis"):
             st.session_state.show_register = True
-            st.experimental_rerun()
+            rerun()
 

--- a/modules/user_admin.py
+++ b/modules/user_admin.py
@@ -2,6 +2,13 @@ import streamlit as st
 import pandas as pd
 
 
+def rerun():
+    if hasattr(st, "rerun"):
+        st.rerun()
+    else:
+        st.experimental_rerun()
+
+
 def show(conn, c):
     st.title("Naudotojų patvirtinimas")
     df = pd.read_sql_query("SELECT id, username FROM users WHERE aktyvus = 0", conn)
@@ -16,8 +23,8 @@ def show(conn, c):
         if cols[1].button("Patvirtinti", key=f"approve_{row['id']}"):
             c.execute("UPDATE users SET aktyvus = 1 WHERE id = ?", (row['id'],))
             conn.commit()
-            st.experimental_rerun()
+            rerun()
         if cols[2].button("Šalinti", key=f"delete_{row['id']}"):
             c.execute("DELETE FROM users WHERE id = ?", (row['id'],))
             conn.commit()
-            st.experimental_rerun()
+            rerun()


### PR DESCRIPTION
## Summary
- add a `rerun()` helper in `login.py` and `user_admin.py`
- use `rerun()` in place of `st.experimental_rerun()`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685d46339f388324b67b2aaff5e7999e