### PR TITLE
Add FastAPI backend skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,14 @@ This repository contains a Streamlit based application for logistics companies. 
 Paleidus programą veikia prisijungimo sistema. Pirmą kartą duomenų bazėje automatiškai sukuriamas naudotojas **admin** su slaptažodžiu **admin**. Prisijungus šiuo vartotoju galima patvirtinti kitų naudotojų registracijas.
 
 Prisijungimo formoje galima pasirinkti „Registruotis“ ir pateikti naujo vartotojo paraišką. Nauji naudotojai įrašomi su neaktyviu statusu ir negali prisijungti, kol administratorius jų nepatvirtins. Administratorius meniu skiltyje „Registracijos“ mato laukiančius vartotojus ir gali juos patvirtinti arba pašalinti.
+
+## FastAPI Multi-tenant Backend
+
+A minimal FastAPI backend is provided under `fastapi_app`. It uses PostgreSQL and SQLAlchemy.
+To run it locally with Docker:
+
+```bash
+docker-compose -f fastapi_app/docker-compose.yml up --build
+```
+
+The API exposes endpoints for user creation and JWT-based login.

--- a/fastapi_app/Dockerfile
+++ b/fastapi_app/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY ./app ./app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/fastapi_app/app/__init__.py
+++ b/fastapi_app/app/__init__.py
@@ -1,0 +1,1 @@
+"""Multi-tenant FastAPI application."""

--- a/fastapi_app/app/auth.py
+++ b/fastapi_app/app/auth.py
@@ -1,0 +1,60 @@
+import os
+from datetime import datetime, timedelta
+import jwt
+from fastapi import HTTPException, status, Depends
+from fastapi.security import OAuth2PasswordBearer
+from sqlalchemy.orm import Session
+import bcrypt
+
+from .database import SessionLocal
+from . import models
+
+SECRET_KEY = os.getenv('SECRET_KEY', 'secret')
+ALGORITHM = 'HS256'
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl='login')
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def hash_password(password: str) -> str:
+    return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
+
+
+def verify_password(password: str, hashed: str) -> bool:
+    return bcrypt.checkpw(password.encode(), hashed.encode())
+
+
+def authenticate_user(db: Session, email: str, password: str):
+    user = db.query(models.User).filter(models.User.email == email).first()
+    if not user or not verify_password(password, user.hashed_password):
+        return None
+    return user
+
+
+def create_access_token(data: dict, expires_delta: timedelta | None = None):
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    to_encode['exp'] = expire
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+
+def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)):
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+    except jwt.PyJWTError:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail='Invalid token')
+    user_id = payload.get('sub')
+    if user_id is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail='Invalid token')
+    user = db.query(models.User).filter(models.User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail='User not found')
+    return user

--- a/fastapi_app/app/crud.py
+++ b/fastapi_app/app/crud.py
@@ -1,0 +1,23 @@
+from sqlalchemy.orm import Session
+from uuid import UUID
+from . import models, schemas, auth
+
+
+def create_user(db: Session, user: schemas.UserCreate) -> models.User:
+    db_user = models.User(
+        email=user.email,
+        hashed_password=auth.hash_password(user.password),
+        full_name=user.full_name,
+    )
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+
+def get_user(db: Session, user_id: UUID) -> models.User | None:
+    return db.query(models.User).filter(models.User.id == user_id).first()
+
+
+def get_user_by_email(db: Session, email: str) -> models.User | None:
+    return db.query(models.User).filter(models.User.email == email).first()

--- a/fastapi_app/app/database.py
+++ b/fastapi_app/app/database.py
@@ -1,0 +1,10 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://app:password@localhost/appdb")
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()

--- a/fastapi_app/app/dependencies.py
+++ b/fastapi_app/app/dependencies.py
@@ -1,0 +1,16 @@
+from fastapi import Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from typing import List
+from uuid import UUID
+
+from . import models, auth
+from .auth import get_db, get_current_user
+
+
+def requires_roles(required: List[str]):
+    def wrapper(current_user = Depends(get_current_user), db: Session = Depends(get_db)):
+        user_roles = [ut.role.name for ut in current_user.tenants]
+        if not any(role in user_roles for role in required):
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail='Insufficient role')
+        return current_user
+    return wrapper

--- a/fastapi_app/app/main.py
+++ b/fastapi_app/app/main.py
@@ -1,0 +1,29 @@
+from fastapi import FastAPI, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from fastapi.security import OAuth2PasswordRequestForm
+
+from . import models, schemas, crud, auth, dependencies
+from .database import engine, Base
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI()
+
+@app.post('/login', response_model=schemas.Token)
+def login(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(auth.get_db)):
+    user = auth.authenticate_user(db, form_data.username, form_data.password)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail='Incorrect credentials')
+    access_token = auth.create_access_token({'sub': str(user.id)})
+    return {'access_token': access_token, 'token_type': 'bearer'}
+
+@app.post('/users', response_model=schemas.User)
+def create_user(user: schemas.UserCreate, db: Session = Depends(auth.get_db)):
+    db_user = crud.get_user_by_email(db, user.email)
+    if db_user:
+        raise HTTPException(status_code=400, detail='Email already registered')
+    return crud.create_user(db, user)
+
+@app.get('/users/me', response_model=schemas.User)
+def read_current_user(current_user=Depends(auth.get_current_user)):
+    return current_user

--- a/fastapi_app/app/models.py
+++ b/fastapi_app/app/models.py
@@ -1,0 +1,41 @@
+from sqlalchemy import Column, String, Integer, ForeignKey, Table
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+import uuid
+
+from .database import Base
+
+class Tenant(Base):
+    __tablename__ = 'tenants'
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name = Column(String, unique=True, nullable=False)
+    users = relationship('UserTenant', back_populates='tenant')
+
+class User(Base):
+    __tablename__ = 'users'
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    email = Column(String, unique=True, nullable=False)
+    hashed_password = Column(String, nullable=False)
+    full_name = Column(String)
+    tenants = relationship('UserTenant', back_populates='user')
+
+class Role(Base):
+    __tablename__ = 'roles'
+    id = Column(Integer, primary_key=True)
+    name = Column(String, unique=True, nullable=False)
+
+class UserTenant(Base):
+    __tablename__ = 'user_tenants'
+    user_id = Column(UUID(as_uuid=True), ForeignKey('users.id'), primary_key=True)
+    tenant_id = Column(UUID(as_uuid=True), ForeignKey('tenants.id'), primary_key=True)
+    role_id = Column(Integer, ForeignKey('roles.id'))
+
+    user = relationship('User', back_populates='tenants')
+    tenant = relationship('Tenant', back_populates='users')
+    role = relationship('Role')
+
+class TenantCollaboration(Base):
+    __tablename__ = 'tenant_collaborations'
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    tenant_a_id = Column(UUID(as_uuid=True), ForeignKey('tenants.id'))
+    tenant_b_id = Column(UUID(as_uuid=True), ForeignKey('tenants.id'))

--- a/fastapi_app/app/schemas.py
+++ b/fastapi_app/app/schemas.py
@@ -1,0 +1,38 @@
+from typing import List, Optional
+from uuid import UUID
+from pydantic import BaseModel, EmailStr
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str
+
+class TokenData(BaseModel):
+    user_id: Optional[UUID]
+    tenant_id: Optional[UUID]
+
+class UserBase(BaseModel):
+    email: EmailStr
+    full_name: Optional[str] = None
+
+class UserCreate(UserBase):
+    password: str
+
+class User(UserBase):
+    id: UUID
+
+    class Config:
+        orm_mode = True
+
+class Tenant(BaseModel):
+    id: UUID
+    name: str
+
+    class Config:
+        orm_mode = True
+
+class Role(BaseModel):
+    id: int
+    name: str
+
+    class Config:
+        orm_mode = True

--- a/fastapi_app/docker-compose.yml
+++ b/fastapi_app/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.9'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: app
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: appdb
+    volumes:
+      - db_data:/var/lib/postgresql/data
+  web:
+    build: .
+    ports:
+      - "8000:8000"
+    environment:
+      DATABASE_URL: postgresql://app:password@db:5432/appdb
+    depends_on:
+      - db
+volumes:
+  db_data:

--- a/fastapi_app/requirements.txt
+++ b/fastapi_app/requirements.txt
@@ -1,0 +1,8 @@
+fastapi
+uvicorn
+sqlalchemy
+psycopg2-binary
+pyjwt
+bcrypt
+alembic
+python-dotenv


### PR DESCRIPTION
## Summary
- add skeleton FastAPI backend with SQLAlchemy models
- provide auth helpers and example login and user endpoints
- add Docker setup for PostgreSQL backed API
- document how to run the new backend

## Testing
- `python -m py_compile fastapi_app/app/*.py`


------
https://chatgpt.com/codex/tasks/task_e_685d58f6a0148324aa4738d7b2598933