### PR TITLE
Add full multi-tenant backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,19 @@ This repository contains a Streamlit based application for logistics companies. 
 Paleidus programą veikia prisijungimo sistema. Pirmą kartą duomenų bazėje automatiškai sukuriamas naudotojas **admin** su slaptažodžiu **admin**. Prisijungus šiuo vartotoju galima patvirtinti kitų naudotojų registracijas.
 
 Prisijungimo formoje galima pasirinkti „Registruotis“ ir pateikti naujo vartotojo paraišką. Nauji naudotojai įrašomi su neaktyviu statusu ir negali prisijungti, kol administratorius jų nepatvirtins. Administratorius meniu skiltyje „Registracijos“ mato laukiančius vartotojus ir gali juos patvirtinti arba pašalinti.
+
+## FastAPI Multi-tenant Backend
+
+A minimal FastAPI backend is provided under `fastapi_app`. It uses PostgreSQL and SQLAlchemy.
+To run it locally with Docker:
+
+```bash
+docker-compose -f fastapi_app/docker-compose.yml up --build
+```
+
+The API exposes endpoints for tenant and user management using JWT tokens.
+Example workflow:
+1. Create a tenant as superadmin via `POST /superadmin/tenants`.
+2. Assign a tenant admin using `POST /superadmin/tenants/{tenant_id}/admins`.
+3. Tenant admins can create users in their tenant via `POST /{tenant_id}/users`.
+4. Users authenticate using `/auth/login` and may refresh tokens via `/auth/refresh`.

--- a/fastapi_app/Dockerfile
+++ b/fastapi_app/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY ./app ./app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/fastapi_app/app/__init__.py
+++ b/fastapi_app/app/__init__.py
@@ -1,0 +1,1 @@
+"""Multi-tenant FastAPI application."""

--- a/fastapi_app/app/auth.py
+++ b/fastapi_app/app/auth.py
@@ -1,0 +1,96 @@
+import os
+from datetime import datetime, timedelta
+import jwt
+from fastapi import HTTPException, status, Depends
+from fastapi.security import OAuth2PasswordBearer
+from sqlalchemy.orm import Session
+import bcrypt
+
+from .database import SessionLocal
+from . import models
+
+SECRET_KEY = os.getenv('SECRET_KEY', 'secret')
+ALGORITHM = 'HS256'
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+REFRESH_TOKEN_EXPIRE_MINUTES = 60 * 24
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl='login')
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def hash_password(password: str) -> str:
+    return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
+
+
+def verify_password(password: str, hashed: str) -> bool:
+    return bcrypt.checkpw(password.encode(), hashed.encode())
+
+
+def authenticate_user(db: Session, email: str, password: str):
+    user = db.query(models.User).filter(models.User.email == email).first()
+    if not user:
+        return None
+    if user.lockout_until and user.lockout_until > datetime.utcnow():
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail='Account locked')
+    if not verify_password(password, user.hashed_password):
+        user.failed_login_attempts += 1
+        if user.failed_login_attempts >= 5:
+            user.lockout_until = datetime.utcnow() + timedelta(minutes=15)
+        db.commit()
+        return None
+    user.failed_login_attempts = 0
+    user.lockout_until = None
+    db.commit()
+    return user
+
+
+def create_access_token(data: dict, expires_delta: timedelta | None = None):
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    to_encode['exp'] = expire
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+
+def create_refresh_token(data: dict, expires_delta: timedelta | None = None):
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=REFRESH_TOKEN_EXPIRE_MINUTES))
+    to_encode = data.copy()
+    to_encode['exp'] = expire
+    to_encode['type'] = 'refresh'
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+
+def decode_token(token: str):
+    try:
+        return jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+    except jwt.PyJWTError:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail='Invalid token')
+
+
+def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)):
+    payload = decode_token(token)
+    user_id = payload.get('sub')
+    if user_id is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail='Invalid token')
+    user = db.query(models.User).filter(models.User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail='User not found')
+    return user
+
+
+def get_current_user_and_tenant(token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)):
+    payload = decode_token(token)
+    user_id = payload.get('sub')
+    tenant_id = payload.get('tenant_id')
+    if not user_id or not tenant_id:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail='Invalid token')
+    user = db.query(models.User).filter(models.User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail='User not found')
+    return user, tenant_id

--- a/fastapi_app/app/crud.py
+++ b/fastapi_app/app/crud.py
@@ -1,0 +1,70 @@
+from sqlalchemy.orm import Session
+from uuid import UUID
+from . import models, schemas, auth
+
+
+def create_user(db: Session, user: schemas.UserCreate) -> models.User:
+    db_user = models.User(
+        email=user.email,
+        hashed_password=auth.hash_password(user.password),
+        full_name=user.full_name,
+    )
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+
+def get_user(db: Session, user_id: UUID) -> models.User | None:
+    return db.query(models.User).filter(models.User.id == user_id).first()
+
+
+def get_user_by_email(db: Session, email: str) -> models.User | None:
+    return db.query(models.User).filter(models.User.email == email).first()
+
+
+def create_tenant(db: Session, tenant: schemas.TenantCreate) -> models.Tenant:
+    db_tenant = models.Tenant(name=tenant.name)
+    db.add(db_tenant)
+    db.commit()
+    db.refresh(db_tenant)
+    return db_tenant
+
+
+def add_user_to_tenant(db: Session, user: models.User, tenant: models.Tenant, role: models.Role):
+    membership = models.UserTenant(user=user, tenant=tenant, role=role)
+    db.add(membership)
+    db.commit()
+
+
+def get_role(db: Session, name: models.RoleName) -> models.Role:
+    role = db.query(models.Role).filter(models.Role.name == name.value).first()
+    if not role:
+        role = models.Role(name=name.value)
+        db.add(role)
+        db.commit()
+        db.refresh(role)
+    return role
+
+
+def create_document(db: Session, tenant_id: UUID, content: str) -> models.Document:
+    doc = models.Document(tenant_id=tenant_id, content=content)
+    db.add(doc)
+    db.commit()
+    db.refresh(doc)
+    return doc
+
+
+def get_documents_for_tenant(db: Session, tenant_id: UUID):
+    return db.query(models.Document).filter(models.Document.tenant_id == tenant_id).all()
+
+
+def get_shared_documents(db: Session, tenant_id: UUID):
+    tenant_ids = [tenant_id]
+    collaborations = db.query(models.TenantCollaboration).filter(
+        (models.TenantCollaboration.tenant_a_id == tenant_id) |
+        (models.TenantCollaboration.tenant_b_id == tenant_id)
+    ).all()
+    for c in collaborations:
+        tenant_ids.append(c.tenant_b_id if c.tenant_a_id == tenant_id else c.tenant_a_id)
+    return db.query(models.Document).filter(models.Document.tenant_id.in_(tenant_ids)).all()

--- a/fastapi_app/app/database.py
+++ b/fastapi_app/app/database.py
@@ -1,0 +1,10 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://app:password@localhost/appdb")
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()

--- a/fastapi_app/app/dependencies.py
+++ b/fastapi_app/app/dependencies.py
@@ -1,0 +1,22 @@
+from fastapi import Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from typing import List
+from uuid import UUID
+
+from . import models, auth
+from .auth import get_db, get_current_user_and_tenant
+
+
+def requires_roles(required: List[models.RoleName]):
+    def wrapper(user_and_tenant = Depends(get_current_user_and_tenant), db: Session = Depends(get_db)):
+        user, tenant_id = user_and_tenant
+        membership = db.query(models.UserTenant).filter(
+            models.UserTenant.user_id == user.id,
+            models.UserTenant.tenant_id == tenant_id
+        ).first()
+        if not membership or membership.role.name not in [r.value for r in required]:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail='Insufficient role')
+        # set session variable for RLS
+        db.execute("SET app.current_tenant = '{}'".format(tenant_id))
+        return (user, tenant_id)
+    return wrapper

--- a/fastapi_app/app/main.py
+++ b/fastapi_app/app/main.py
@@ -1,0 +1,86 @@
+from fastapi import FastAPI, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from fastapi.security import OAuth2PasswordRequestForm
+from uuid import UUID
+
+from . import models, schemas, crud, auth, dependencies
+from .database import engine, Base
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI()
+
+
+@app.post('/auth/login', response_model=schemas.Token)
+def login(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(auth.get_db)):
+    user = auth.authenticate_user(db, form_data.username, form_data.password)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail='Incorrect credentials')
+    # assume first tenant of user
+    if not user.tenants:
+        raise HTTPException(status_code=400, detail='User has no tenant')
+    tenant_id = user.tenants[0].tenant_id
+    roles = [ut.role.name for ut in user.tenants if ut.tenant_id == tenant_id]
+    access_token = auth.create_access_token({'sub': str(user.id), 'tenant_id': str(tenant_id), 'roles': roles})
+    refresh_token = auth.create_refresh_token({'sub': str(user.id), 'tenant_id': str(tenant_id), 'roles': roles})
+    return {'access_token': access_token, 'refresh_token': refresh_token, 'token_type': 'bearer'}
+
+
+@app.post('/auth/refresh', response_model=schemas.Token)
+def refresh(token: str = Depends(auth.oauth2_scheme)):
+    payload = auth.decode_token(token)
+    if payload.get('type') != 'refresh':
+        raise HTTPException(status_code=400, detail='Invalid refresh token')
+    new_access = auth.create_access_token({'sub': payload['sub'], 'tenant_id': payload['tenant_id'], 'roles': payload.get('roles', [])})
+    new_refresh = auth.create_refresh_token({'sub': payload['sub'], 'tenant_id': payload['tenant_id'], 'roles': payload.get('roles', [])})
+    return {'access_token': new_access, 'refresh_token': new_refresh, 'token_type': 'bearer'}
+
+
+@app.post('/superadmin/tenants', response_model=schemas.Tenant)
+def create_tenant(tenant: schemas.TenantCreate, user_tenant = Depends(dependencies.requires_roles([models.RoleName.SUPERADMIN])), db: Session = Depends(auth.get_db)):
+    _, _ = user_tenant
+    return crud.create_tenant(db, tenant)
+
+
+@app.post('/superadmin/tenants/{tenant_id}/admins')
+def assign_admin(tenant_id: UUID, email: schemas.UserTenantCreate, user_tenant = Depends(dependencies.requires_roles([models.RoleName.SUPERADMIN])), db: Session = Depends(auth.get_db)):
+    user, _ = user_tenant
+    db_user = crud.get_user_by_email(db, email.email)
+    if not db_user:
+        db_user = crud.create_user(db, schemas.UserCreate(email=email.email, password=email.password, full_name=email.full_name))
+    tenant = db.query(models.Tenant).filter(models.Tenant.id == tenant_id).first()
+    if not tenant:
+        raise HTTPException(status_code=404, detail='Tenant not found')
+    role = crud.get_role(db, models.RoleName.TENANT_ADMIN)
+    crud.add_user_to_tenant(db, db_user, tenant, role)
+    return {"detail": "admin assigned"}
+
+
+@app.post('/{tenant_id}/users', response_model=schemas.User)
+def create_user_for_tenant(tenant_id: UUID, user_in: schemas.UserTenantCreate, user_tenant = Depends(dependencies.requires_roles([models.RoleName.TENANT_ADMIN, models.RoleName.SUPERADMIN])), db: Session = Depends(auth.get_db)):
+    _, current_tenant_id = user_tenant
+    if str(current_tenant_id) != str(tenant_id):
+        raise HTTPException(status_code=403, detail='Cross tenant creation forbidden')
+    db_user = crud.get_user_by_email(db, user_in.email)
+    if db_user:
+        raise HTTPException(status_code=400, detail='Email already registered')
+    db_user = crud.create_user(db, schemas.UserCreate(email=user_in.email, password=user_in.password, full_name=user_in.full_name))
+    role = crud.get_role(db, user_in.role)
+    tenant = db.query(models.Tenant).filter(models.Tenant.id == tenant_id).first()
+    crud.add_user_to_tenant(db, db_user, tenant, role)
+    return db_user
+
+
+@app.get('/{tenant_id}/shared-data', response_model=list[schemas.Document])
+def get_shared_documents(tenant_id: UUID, user_tenant = Depends(dependencies.requires_roles([models.RoleName.USER, models.RoleName.TENANT_ADMIN, models.RoleName.SUPERADMIN])), db: Session = Depends(auth.get_db)):
+    _, current_tenant_id = user_tenant
+    if str(current_tenant_id) != str(tenant_id):
+        raise HTTPException(status_code=403, detail='Forbidden')
+    docs = crud.get_shared_documents(db, tenant_id)
+    return docs
+
+
+@app.get('/users/me', response_model=schemas.User)
+def read_current_user(user_and_tenant = Depends(dependencies.requires_roles([models.RoleName.USER, models.RoleName.TENANT_ADMIN, models.RoleName.SUPERADMIN]))):
+    user, _ = user_and_tenant
+    return user

--- a/fastapi_app/app/models.py
+++ b/fastapi_app/app/models.py
@@ -1,0 +1,60 @@
+from sqlalchemy import Column, String, Integer, ForeignKey, DateTime
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+import uuid
+from datetime import datetime
+import enum
+
+from .database import Base
+
+class Tenant(Base):
+    __tablename__ = 'tenants'
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name = Column(String, unique=True, nullable=False)
+    users = relationship('UserTenant', back_populates='tenant')
+    collaborations_a = relationship('TenantCollaboration', foreign_keys='TenantCollaboration.tenant_a_id')
+    collaborations_b = relationship('TenantCollaboration', foreign_keys='TenantCollaboration.tenant_b_id')
+
+class User(Base):
+    __tablename__ = 'users'
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    email = Column(String, unique=True, nullable=False)
+    hashed_password = Column(String, nullable=False)
+    full_name = Column(String)
+    failed_login_attempts = Column(Integer, default=0)
+    lockout_until = Column(DateTime)
+    tenants = relationship('UserTenant', back_populates='user')
+
+class RoleName(str, enum.Enum):
+    SUPERADMIN = 'SUPERADMIN'
+    TENANT_ADMIN = 'TENANT_ADMIN'
+    USER = 'USER'
+
+
+class Role(Base):
+    __tablename__ = 'roles'
+    id = Column(Integer, primary_key=True)
+    name = Column(String, unique=True, nullable=False)
+
+class UserTenant(Base):
+    __tablename__ = 'user_tenants'
+    user_id = Column(UUID(as_uuid=True), ForeignKey('users.id'), primary_key=True)
+    tenant_id = Column(UUID(as_uuid=True), ForeignKey('tenants.id'), primary_key=True)
+    role_id = Column(Integer, ForeignKey('roles.id'))
+
+    user = relationship('User', back_populates='tenants')
+    tenant = relationship('Tenant', back_populates='users')
+    role = relationship('Role')
+
+class TenantCollaboration(Base):
+    __tablename__ = 'tenant_collaborations'
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    tenant_a_id = Column(UUID(as_uuid=True), ForeignKey('tenants.id'))
+    tenant_b_id = Column(UUID(as_uuid=True), ForeignKey('tenants.id'))
+
+
+class Document(Base):
+    __tablename__ = 'documents'
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    tenant_id = Column(UUID(as_uuid=True), ForeignKey('tenants.id'))
+    content = Column(String)

--- a/fastapi_app/app/schemas.py
+++ b/fastapi_app/app/schemas.py
@@ -1,0 +1,59 @@
+from typing import List, Optional
+from uuid import UUID
+from pydantic import BaseModel, EmailStr
+from .models import RoleName
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str
+    refresh_token: Optional[str] = None
+
+class TokenData(BaseModel):
+    user_id: Optional[UUID]
+    tenant_id: Optional[UUID]
+
+class UserBase(BaseModel):
+    email: EmailStr
+    full_name: Optional[str] = None
+
+class UserCreate(UserBase):
+    password: str
+
+class User(UserBase):
+    id: UUID
+
+    class Config:
+        orm_mode = True
+
+class Tenant(BaseModel):
+    id: UUID
+    name: str
+
+    class Config:
+        orm_mode = True
+
+class TenantCreate(BaseModel):
+    name: str
+
+
+class UserTenantCreate(BaseModel):
+    email: EmailStr
+    password: str
+    full_name: Optional[str] = None
+    role: RoleName
+
+class Role(BaseModel):
+    id: int
+    name: RoleName
+
+    class Config:
+        orm_mode = True
+
+
+class Document(BaseModel):
+    id: UUID
+    tenant_id: UUID
+    content: str
+
+    class Config:
+        orm_mode = True

--- a/fastapi_app/docker-compose.yml
+++ b/fastapi_app/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.9'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: app
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: appdb
+    volumes:
+      - db_data:/var/lib/postgresql/data
+  web:
+    build: .
+    ports:
+      - "8000:8000"
+    environment:
+      DATABASE_URL: postgresql://app:password@db:5432/appdb
+    depends_on:
+      - db
+volumes:
+  db_data:

--- a/fastapi_app/requirements.txt
+++ b/fastapi_app/requirements.txt
@@ -1,0 +1,8 @@
+fastapi
+uvicorn
+sqlalchemy
+psycopg2-binary
+pyjwt
+bcrypt
+alembic
+python-dotenv

--- a/fastapi_app/tests/test_basic.py
+++ b/fastapi_app/tests/test_basic.py
@@ -1,0 +1,45 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from fastapi_app.app.main import app
+from fastapi_app.app.database import Base, get_db
+from fastapi_app.app import models, crud, schemas
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///:memory:"
+engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base.metadata.create_all(bind=engine)
+
+# Dependency override
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+app.dependency_overrides[get_db] = override_get_db
+
+client = TestClient(app)
+
+
+def create_superadmin(db):
+    role = crud.get_role(db, models.RoleName.SUPERADMIN)
+    user = crud.create_user(db, schemas.UserCreate(email="admin@example.com", password="secret", full_name="Admin"))
+    tenant = crud.create_tenant(db, schemas.TenantCreate(name="acme"))
+    crud.add_user_to_tenant(db, user, tenant, role)
+    return user, tenant
+
+
+def test_login_flow():
+    db = next(override_get_db())
+    user, tenant = create_superadmin(db)
+    response = client.post("/auth/login", data={"username": user.email, "password": "secret"})
+    assert response.status_code == 200
+    data = response.json()
+    assert "access_token" in data
+


### PR DESCRIPTION
## Summary
- extend FastAPI backend to include roles, tenants and documents
- add JWT refresh tokens, account lockout, and RLS dependency
- implement admin and user endpoints for tenant management
- include simple pytest-based test scaffold
- update README with example API workflow

## Testing
- `python -m py_compile fastapi_app/app/*.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685d58f6a0148324aa4738d7b2598933