### PR TITLE
Fix FastAPI setup and add basic tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,10 @@ To run it locally with Docker:
 docker-compose -f fastapi_app/docker-compose.yml up --build
 ```
 
+If running without Docker, install the FastAPI dependencies first:
+
+```bash
+pip install -r fastapi_app/requirements.txt
+```
+
 The API exposes endpoints for user creation and JWT-based login.

--- a/fastapi_app/app/auth.py
+++ b/fastapi_app/app/auth.py
@@ -13,7 +13,8 @@ SECRET_KEY = os.getenv('SECRET_KEY', 'secret')
 ALGORITHM = 'HS256'
 ACCESS_TOKEN_EXPIRE_MINUTES = 30
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl='login')
+# OAuth2PasswordBearer tokenUrl should match the login endpoint path
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl='auth/login')
 
 
 def get_db():

--- a/fastapi_app/app/main.py
+++ b/fastapi_app/app/main.py
@@ -9,7 +9,8 @@ Base.metadata.create_all(bind=engine)
 
 app = FastAPI()
 
-@app.post('/login', response_model=schemas.Token)
+# Login endpoint used by OAuth2PasswordBearer
+@app.post('/auth/login', response_model=schemas.Token)
 def login(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(auth.get_db)):
     user = auth.authenticate_user(db, form_data.username, form_data.password)
     if not user:

--- a/fastapi_app/requirements.txt
+++ b/fastapi_app/requirements.txt
@@ -6,3 +6,4 @@ pyjwt
 bcrypt
 alembic
 python-dotenv
+httpx

--- a/fastapi_app/tests/test_basic.py
+++ b/fastapi_app/tests/test_basic.py
@@ -1,0 +1,35 @@
+import uuid
+from fastapi.testclient import TestClient
+from fastapi_app.app.main import app
+from fastapi_app.app.auth import get_db, hash_password
+from fastapi_app.app.database import Base
+from fastapi_app.app import models
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+SQLALCHEMY_DATABASE_URL = 'sqlite:///./test.db'
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={'check_same_thread': False}
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base.metadata.create_all(bind=engine)
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+app.dependency_overrides[get_db] = override_get_db
+client = TestClient(app)
+
+def test_login_flow():
+    with TestingSessionLocal() as db:
+        user = models.User(email='user@example.com', hashed_password=hash_password('password'), full_name='User')
+        db.add(user)
+        db.commit()
+    response = client.post('/auth/login', data={'username': 'user@example.com', 'password': 'password'})
+    assert response.status_code == 200
+    assert 'access_token' in response.json()


### PR DESCRIPTION
## Summary
- configure OAuth2 token URL and login route under `/auth`
- add `httpx` dependency for tests
- document installing requirements for FastAPI
- include a minimal login test for FastAPI

## Testing
- `python3 -m py_compile fastapi_app/app/*.py`
- `pytest -q fastapi_app/tests/test_basic.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685db3a943a48324b83b40bd38987ad1