### PR TITLE
Set up Alembic for FastAPI app

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,17 @@ pip install -r fastapi_app/requirements.txt
 ```
 
 The API exposes endpoints for user creation and JWT-based login.
+
+### Database migrations
+
+Alembic configuration lives in `fastapi_app/alembic`. To apply migrations run:
+
+```bash
+alembic -c fastapi_app/alembic.ini upgrade head
+```
+
+When models change a new migration can be generated with:
+
+```bash
+alembic -c fastapi_app/alembic.ini revision --autogenerate -m "message"
+```

--- a/fastapi_app/alembic.ini
+++ b/fastapi_app/alembic.ini
@@ -1,0 +1,24 @@
+[alembic]
+script_location = fastapi_app/alembic
+
+[loggers]
+keys = root
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/fastapi_app/alembic/env.py
+++ b/fastapi_app/alembic/env.py
@@ -1,0 +1,48 @@
+import os
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+from fastapi_app.app.database import Base, DATABASE_URL
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+config.set_main_option("sqlalchemy.url", DATABASE_URL)
+
+target_metadata = Base.metadata
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/fastapi_app/alembic/versions/0001_initial.py
+++ b/fastapi_app/alembic/versions/0001_initial.py
@@ -1,0 +1,61 @@
+"""create initial tables
+
+Revision ID: 0001_initial
+Revises: 
+Create Date: 2024-01-01 00:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '0001_initial'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.create_table(
+        'tenants',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column('name', sa.String(), nullable=False, unique=True),
+    )
+    op.create_table(
+        'users',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column('email', sa.String(), nullable=False, unique=True),
+        sa.Column('hashed_password', sa.String(), nullable=False),
+        sa.Column('full_name', sa.String()),
+    )
+    op.create_table(
+        'roles',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('name', sa.String(), nullable=False, unique=True),
+    )
+    op.create_table(
+        'user_tenants',
+        sa.Column('user_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('users.id'), primary_key=True, nullable=False),
+        sa.Column('tenant_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('tenants.id'), primary_key=True, nullable=False),
+        sa.Column('role_id', sa.Integer(), sa.ForeignKey('roles.id')),
+    )
+    op.create_table(
+        'tenant_collaborations',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column('tenant_a_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('tenants.id')),
+        sa.Column('tenant_b_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('tenants.id')),
+    )
+    op.create_table(
+        'documents',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column('tenant_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('tenants.id')),
+        sa.Column('content', sa.String(), nullable=False),
+    )
+
+def downgrade() -> None:
+    op.drop_table('documents')
+    op.drop_table('tenant_collaborations')
+    op.drop_table('user_tenants')
+    op.drop_table('roles')
+    op.drop_table('users')
+    op.drop_table('tenants')

--- a/fastapi_app/app/main.py
+++ b/fastapi_app/app/main.py
@@ -6,13 +6,12 @@ import os
 
 
 from . import models, schemas, crud, auth, dependencies
-from .database import engine, Base
+from .database import Base
 
 def run_migrations():
-    cfg = Config(os.path.join(os.path.dirname(__file__), 'alembic.ini'))
+    base_dir = os.path.dirname(os.path.dirname(__file__))
+    cfg = Config(os.path.join(base_dir, 'alembic.ini'))
     command.upgrade(cfg, 'head')
-
-Base.metadata.create_all(bind=engine)
 
 app = FastAPI()
 


### PR DESCRIPTION
## Summary
- set up Alembic in `fastapi_app`
- remove `Base.metadata.create_all` and run migrations on startup
- document how to run migrations in README

## Testing
- `pytest -q fastapi_app/tests/test_basic.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685e19d2aac08324be0521df98d80cd6