### PR TITLE
Add JWT refresh token flow

### DIFF
--- a/fastapi_app/app/schemas.py
+++ b/fastapi_app/app/schemas.py
@@ -6,6 +6,14 @@ class Token(BaseModel):
     access_token: str
     token_type: str
 
+
+class TokenPair(Token):
+    refresh_token: str
+
+
+class RefreshRequest(BaseModel):
+    refresh_token: str
+
 class LoginRequest(BaseModel):
     email: EmailStr
     password: str

--- a/fastapi_app/tests/test_basic.py
+++ b/fastapi_app/tests/test_basic.py
@@ -35,6 +35,12 @@ def test_login_flow():
         assoc = models.UserTenant(user_id=user.id, tenant_id=tenant.id, role_id=role.id)
         db.add(assoc)
         db.commit()
-    response = client.post('/login', json={'email': 'user@example.com', 'password': 'password', 'tenant_id': str(tenant.id)})
+    response = client.post('/auth/login', json={'email': 'user@example.com', 'password': 'password', 'tenant_id': str(tenant.id)})
     assert response.status_code == 200
-    assert 'access_token' in response.json()
+    tokens = response.json()
+    assert 'access_token' in tokens
+    assert 'refresh_token' in tokens
+
+    refresh_resp = client.post('/auth/refresh', json={'refresh_token': tokens['refresh_token']})
+    assert refresh_resp.status_code == 200
+    assert 'access_token' in refresh_resp.json()


### PR DESCRIPTION
## Summary
- extend schemas with refresh token models
- implement refresh token helpers in auth module
- add `/auth/login` alias with refresh tokens
- add `/auth/refresh` to issue new access tokens
- update tests for new endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685e22de752883249fb51789df60e4a9