### PR TITLE
Require SECRET_KEY env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ If running without Docker, install the FastAPI dependencies first:
 pip install -r fastapi_app/requirements.txt
 ```
 
+The backend requires a `SECRET_KEY` used for JWT signing. Set this environment
+variable or create a `.env` file containing `SECRET_KEY=<your secret>` before
+starting the API. If it is missing the application will fail to start.
+
 The API exposes endpoints for user creation and JWT-based login.
 
 ### Login rate limiting

--- a/fastapi_app/app/auth.py
+++ b/fastapi_app/app/auth.py
@@ -6,11 +6,15 @@ from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy.orm import Session
 from sqlalchemy import text
 import bcrypt
+from dotenv import load_dotenv
 
 from .database import SessionLocal
 from . import models
 
-SECRET_KEY = os.getenv('SECRET_KEY', 'secret')
+load_dotenv()
+SECRET_KEY = os.getenv('SECRET_KEY')
+if not SECRET_KEY:
+    raise RuntimeError('SECRET_KEY environment variable is required')
 ALGORITHM = 'HS256'
 ACCESS_TOKEN_EXPIRE_MINUTES = 30
 REFRESH_TOKEN_EXPIRE_DAYS = 7

--- a/fastapi_app/tests/test_basic.py
+++ b/fastapi_app/tests/test_basic.py
@@ -1,4 +1,6 @@
+import os
 import uuid
+os.environ.setdefault("SECRET_KEY", "test-secret")
 from fastapi.testclient import TestClient
 from fastapi_app.app.main import app
 from fastapi_app.app.auth import get_db, hash_password

--- a/fastapi_app/tests/test_shared_data.py
+++ b/fastapi_app/tests/test_shared_data.py
@@ -1,4 +1,6 @@
+import os
 import uuid
+os.environ.setdefault("SECRET_KEY", "test-secret")
 from fastapi.testclient import TestClient
 from fastapi_app.app.main import app
 from fastapi_app.app.auth import get_db, hash_password


### PR DESCRIPTION
## Summary
- enforce SECRET_KEY via environment variable in auth.py
- document the requirement in README
- set SECRET_KEY for tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685e26dbea008324b0944a15532c12e8