### PR TITLE
Add demo data seeding tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,20 @@ When models change a new migration can be generated with:
 ```bash
 alembic -c fastapi_app/alembic.ini revision --autogenerate -m "message"
 ```
+
+## Demo duomenys
+
+Norėdami greitai išbandyti aplikaciją su pavyzdiniais įrašais, galite
+automatiškai užpildyti duomenų bazę demonstraciniais duomenimis:
+
+```bash
+python seed_demo_data.py
+```
+
+Visi demo įrašai pažymėti prefiksu `DEMO_`. Juos pašalinti galima
+paleidus:
+
+```bash
+python seed_demo_data.py --clear
+```
+

--- a/seed_demo_data.py
+++ b/seed_demo_data.py
@@ -1,0 +1,138 @@
+import argparse
+from datetime import date, timedelta
+from db import init_db
+
+PREFIX = "DEMO_"
+
+
+def seed_data(conn, c):
+    # Klientai
+    clients = [
+        {"pavadinimas": f"{PREFIX}Klientas1", "vat_numeris": "DEMO123", "salis": "Lietuva", "miestas": "Vilnius", "regionas": ""},
+        {"pavadinimas": f"{PREFIX}Klientas2", "vat_numeris": "DEMO456", "salis": "Latvija", "miestas": "Ryga", "regionas": ""},
+    ]
+    for cl in clients:
+        c.execute(
+            "INSERT INTO klientai (pavadinimas, vat_numeris, salis, miestas, regionas) VALUES (?,?,?,?,?)",
+            (cl["pavadinimas"], cl["vat_numeris"], cl["salis"], cl["miestas"], cl["regionas"]),
+        )
+
+    # Grupes
+    groups = [
+        ("DEMO_TR", "Demo Transporto", ""),
+        ("DEMO_EKSP", "Demo Ekspedicija", ""),
+    ]
+    for num, pav, apr in groups:
+        c.execute(
+            "INSERT INTO grupes (numeris, pavadinimas, aprasymas) VALUES (?,?,?)",
+            (num, pav, apr),
+        )
+    conn.commit()
+
+    # Grupiu regionai
+    eksp_id = c.execute("SELECT id FROM grupes WHERE numeris=?", ("DEMO_EKSP",)).fetchone()[0]
+    for region in ["LT01", "LV02", "PL03"]:
+        c.execute(
+            "INSERT INTO grupiu_regionai (grupe_id, regiono_kodas) VALUES (?,?)",
+            (eksp_id, region),
+        )
+
+    # Darbuotojai
+    workers = [
+        ("Jonas", "Jonaitis", "Ekspedicijos vadybininkas", "demo1@example.com", "+37060000001", "DEMO_EKSP"),
+        ("Petras", "Petraitis", "Transporto vadybininkas", "demo2@example.com", "+37060000002", "DEMO_TR"),
+    ]
+    for w in workers:
+        c.execute(
+            "INSERT INTO darbuotojai (vardas, pavarde, pareigybe, el_pastas, telefonas, grupe) VALUES (?,?,?,?,?,?)",
+            w,
+        )
+
+    # Vairuotojai
+    drivers = [
+        ("Tomas", "Tomaitis", "1985", "LT", "", ""),
+        ("Andrius", "Andrejevas", "1990", "LV", "", ""),
+    ]
+    for d in drivers:
+        c.execute(
+            "INSERT INTO vairuotojai (vardas, pavarde, gimimo_metai, tautybe, kadencijos_pabaiga, atostogu_pabaiga) VALUES (?,?,?,?,?,?)",
+            d,
+        )
+
+    # Vilkikai
+    trucks = [
+        ("DEMO_TRUCK1", "Volvo", 2018, date.today().isoformat(), workers[1][0] + " " + workers[1][1], "Tomas Tomaitis", ""),
+        ("DEMO_TRUCK2", "Scania", 2017, date.today().isoformat(), workers[1][0] + " " + workers[1][1], "Andrius Andrejevas", ""),
+    ]
+    for t in trucks:
+        c.execute(
+            "INSERT INTO vilkikai (numeris, marke, pagaminimo_metai, tech_apziura, vadybininkas, vairuotojai, priekaba) VALUES (?,?,?,?,?,?,?)",
+            t,
+        )
+
+    # Priekabos
+    trailers = [
+        ("Tentinė", "DEMO-T1", "Krone", 2018, date.today().isoformat(), "", date.today().isoformat()),
+        ("Šaldytuvas", "DEMO-T2", "Schmitz", 2019, date.today().isoformat(), "", date.today().isoformat()),
+    ]
+    for tr in trailers:
+        c.execute(
+            "INSERT INTO priekabos (priekabu_tipas, numeris, marke, pagaminimo_metai, tech_apziura, priskirtas_vilkikas, draudimas) VALUES (?,?,?,?,?,?,?)",
+            tr,
+        )
+
+    # Kroviniai
+    shipments = [
+        {
+            "klientas": clients[0]["pavadinimas"],
+            "uzsakymo_numeris": "DEMO_CARGO1",
+            "pakrovimo_data": date.today().isoformat(),
+            "iskrovimo_data": (date.today() + timedelta(days=2)).isoformat(),
+            "kilometrai": 500,
+            "frachtas": 1200.0,
+            "busena": "Nesuplanuotas",
+            "pakrovimo_salis": "Lietuva",
+            "pakrovimo_regionas": "LT01",
+            "iskrovimo_salis": "Lenkija",
+            "iskrovimo_regionas": "PL03",
+        }
+    ]
+    for s in shipments:
+        cols = ",".join(s.keys())
+        placeholders = ",".join("?" for _ in s)
+        c.execute(f"INSERT INTO kroviniai ({cols}) VALUES ({placeholders})", tuple(s.values()))
+
+    conn.commit()
+
+
+def clear_data(conn, c):
+    tables = {
+        "kroviniai": "uzsakymo_numeris",
+        "vilkikai": "numeris",
+        "priekabos": "numeris",
+        "darbuotojai": "el_pastas",
+        "vairuotojai": "vardas",
+        "klientai": "pavadinimas",
+        "grupes": "numeris",
+    }
+    for table, col in tables.items():
+        c.execute(f"DELETE FROM {table} WHERE {col} LIKE ?", (f'{PREFIX}%',))
+    c.execute(
+        "DELETE FROM grupiu_regionai WHERE grupe_id IN (SELECT id FROM grupes WHERE numeris LIKE ?)",
+        (f'{PREFIX}%',)
+    )
+    conn.commit()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Seed or clear demo data")
+    parser.add_argument("--clear", action="store_true", help="Remove demo entries")
+    args = parser.parse_args()
+
+    conn, c = init_db()
+    if args.clear:
+        clear_data(conn, c)
+        print("Demo data removed")
+    else:
+        seed_data(conn, c)
+        print("Demo data inserted")


### PR DESCRIPTION
## Summary
- add a `seed_demo_data.py` script for inserting and clearing demo data
- document how to use the script in the README

## Testing
- `pip install -r fastapi_app/requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685e2a3aa57c83249021876e0d004bb8