### PR TITLE
Switch to bcrypt password hashing

### DIFF
--- a/db.py
+++ b/db.py
@@ -1,6 +1,7 @@
 # db.py
 import sqlite3
 import os
+from modules.auth_utils import hash_password
 
 def init_db(db_path: str | None = None):
     """
@@ -180,8 +181,7 @@ def init_db(db_path: str | None = None):
     c.execute("SELECT id FROM users WHERE username = 'admin'")
     row = c.fetchone()
     if not row:
-        import hashlib
-        admin_hash = hashlib.sha256('admin'.encode()).hexdigest()
+        admin_hash = hash_password('admin')
         c.execute(
             "INSERT INTO users (username, password_hash, imone, aktyvus) VALUES (?, ?, ?, 1)",
             ('admin', admin_hash, 'Admin')

--- a/modules/auth_utils.py
+++ b/modules/auth_utils.py
@@ -1,6 +1,6 @@
-import hashlib
+import bcrypt
 
 
 def hash_password(password: str) -> str:
-    """Return SHA-256 hash of the given password."""
-    return hashlib.sha256(password.encode()).hexdigest()
+    """Return bcrypt hash of the given password."""
+    return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()

--- a/modules/login.py
+++ b/modules/login.py
@@ -8,6 +8,7 @@ def rerun():
         st.experimental_rerun()
 
 from .auth_utils import hash_password
+import bcrypt
 
 def verify_user(conn, c, username: str, password: str):
     c.execute(
@@ -15,7 +16,7 @@ def verify_user(conn, c, username: str, password: str):
         (username,)
     )
     row = c.fetchone()
-    if row and row[1] == hash_password(password):
+    if row and bcrypt.checkpw(password.encode(), row[1].encode()):
         return row[0], row[2]
     return (None, None)
 

--- a/tests/test_streamlit_auth.py
+++ b/tests/test_streamlit_auth.py
@@ -1,0 +1,27 @@
+from db import init_db
+from modules import login, auth_utils
+
+
+def test_admin_login(tmp_path):
+    db_file = tmp_path / "t.db"
+    conn, c = init_db(str(db_file))
+    user_id, imone = login.verify_user(conn, c, "admin", "admin")
+    assert user_id is not None
+    assert imone == "Admin"
+    user_id2, _ = login.verify_user(conn, c, "admin", "wrong")
+    assert user_id2 is None
+
+
+def test_user_registration_flow(tmp_path):
+    db_file = tmp_path / "r.db"
+    conn, c = init_db(str(db_file))
+    pw_hash = auth_utils.hash_password("pass123")
+    c.execute(
+        "INSERT INTO users (username, password_hash, imone, aktyvus) VALUES (?, ?, ?, 1)",
+        ("user", pw_hash, "Comp"),
+    )
+    conn.commit()
+    user_id, _ = login.verify_user(conn, c, "user", "pass123")
+    assert user_id is not None
+    bad, _ = login.verify_user(conn, c, "user", "bad")
+    assert bad is None


### PR DESCRIPTION
## Summary
- use `bcrypt` for hashing in `modules/auth_utils`
- update login verification to use `bcrypt.checkpw`
- generate admin user's password with new hashing
- add regression tests for registration and login

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi', 'bcrypt')*

------
https://chatgpt.com/codex/tasks/task_e_685e6dc4ae808324b1bd9846f317bfff