### PR TITLE
Add requirements file for Streamlit app

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@ This repository contains a Streamlit based application for logistics companies. 
 
 ## Setup
 
-1. Create and activate a Python virtual environment.
+1. Create and activate a Python virtual environment and install the
+   required packages from `requirements.txt`.
    ```bash
    python3 -m venv venv
    source venv/bin/activate
-   pip install streamlit pandas
+   pip install -r requirements.txt
    ```
 
 2. Initialize the database. The helper function `init_db()` in `db.py` creates all required tables. It is executed automatically when running `main.py`, but you can also call it manually. The path can be overridden with the `DB_PATH` environment variable:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+streamlit
+pandas
+bcrypt


### PR DESCRIPTION
## Summary
- include a new `requirements.txt` listing Streamlit app dependencies
- update the setup instructions to install packages from the requirements file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685e6f1ea2cc8324be8df8fbdbeee440