### PR TITLE
Adjust admin visibility and user access

### DIFF
--- a/main.py
+++ b/main.py
@@ -55,7 +55,6 @@ module_functions = {
 MODULE_ROLES = {
     "Darbuotojai": ["admin"],
     "Registracijos": ["admin"],
-    "Update": ["admin"],
 }
 
 def allowed(name: str) -> bool:

--- a/modules/user_admin.py
+++ b/modules/user_admin.py
@@ -11,15 +11,20 @@ def rerun():
 
 def show(conn, c):
     st.title("Naudotojų patvirtinimas")
-    df = pd.read_sql_query("SELECT id, username FROM users WHERE aktyvus = 0", conn)
+    df = pd.read_sql_query(
+        "SELECT id, username, imone FROM users WHERE aktyvus = 0", conn
+    )
 
     if df.empty:
         st.info("Nėra laukiančių vartotojų")
         return
 
     for _, row in df.iterrows():
-        cols = st.columns([3, 1, 1])
-        cols[0].write(row['username'])
+        cols = st.columns([4, 1, 1])
+        user_display = row['username']
+        if row.get('imone'):
+            user_display += f" ({row['imone']})"
+        cols[0].write(user_display)
         if cols[1].button("Patvirtinti", key=f"approve_{row['id']}"):
             c.execute("UPDATE users SET aktyvus = 1 WHERE id = ?", (row['id'],))
             conn.commit()


### PR DESCRIPTION
## Summary
- remove Update module role restriction so everyone can see it
- display company name for pending registrations
- let admins view all trucks

## Testing
- `python -m py_compile modules/user_admin.py modules/vilkikai.py main.py`
- `pip install -q -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685fc3b0e05c832480f9d3e20bdd063a