### PR TITLE
Fix missing 'imone' column for trailers

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ This repository contains a Streamlit based application for logistics companies. 
    from db import init_db
    conn, cursor = init_db()  # uses main.db by default or DB_PATH if set
    ```
-   The `init_db()` function now creates an `imone` column in the `vilkikai`
-   table by default. When run on an older database it will automatically add
-   this column if it is missing.
+   The `init_db()` function now creates an `imone` column in both the
+   `vilkikai` and `priekabos` tables by default. When run on an older database
+   it will automatically add this column if it is missing.
 
 3. Start the application:
    ```bash

--- a/db.py
+++ b/db.py
@@ -79,6 +79,11 @@ def init_db(db_path: str | None = None):
             draudimas         DATE
         )
     """)
+    c.execute("PRAGMA table_info(priekabos)")
+    cols = [row[1] for row in c.fetchall()]
+    if 'imone' not in cols:
+        c.execute("ALTER TABLE priekabos ADD COLUMN imone TEXT")
+    conn.commit()
 
     c.execute("""
         CREATE TABLE IF NOT EXISTS grupes (


### PR DESCRIPTION
## Summary
- ensure `init_db` adds the `imone` column to the `priekabos` table
- update README to mention `priekabos` table column

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685feb47cd988324a225b320d904f859