### PR TITLE
Add SECRET_KEY support to FastAPI Docker setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,20 @@ To run it locally with Docker:
 docker-compose -f fastapi_app/docker-compose.yml up --build
 ```
 
+Before starting, copy `fastapi_app/.env.example` to `fastapi_app/.env` and set a
+strong value for `SECRET_KEY`. Docker Compose will read this file and supply the
+variable to the container. Alternatively you can export `SECRET_KEY` in your
+environment.
+
 If running without Docker, install the FastAPI dependencies first:
 
 ```bash
 pip install -r fastapi_app/requirements.txt
 ```
 
-The backend requires a `SECRET_KEY` used for JWT signing. Set this environment
-variable or create a `.env` file containing `SECRET_KEY=<your secret>` before
-starting the API. If it is missing the application will fail to start.
+The backend requires a `SECRET_KEY` used for JWT signing. Ensure the `.env` file
+defines this variable before starting the API; otherwise the application will
+fail to start.
 
 The API exposes endpoints for user creation and JWT-based login.
 

--- a/fastapi_app/.env.example
+++ b/fastapi_app/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and set your secret key
+SECRET_KEY=change-me

--- a/fastapi_app/docker-compose.yml
+++ b/fastapi_app/docker-compose.yml
@@ -12,8 +12,11 @@ services:
     build: .
     ports:
       - "8000:8000"
+    env_file:
+      - .env
     environment:
       DATABASE_URL: postgresql://app:password@db:5432/appdb
+      SECRET_KEY: ${SECRET_KEY}
     depends_on:
       - db
 volumes:


### PR DESCRIPTION
## Summary
- include `.env` file in FastAPI docker-compose configuration
- document environment setup and create `.env.example`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -r fastapi_app/requirements.txt` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686052308d74832484ac784ae21780bd