### PR TITLE
Fix registration reset and domain checks

### DIFF
--- a/modules/register.py
+++ b/modules/register.py
@@ -3,14 +3,21 @@ import streamlit as st
 from .auth_utils import hash_password
 
 
+def rerun():
+    if hasattr(st, "rerun"):
+        st.rerun()
+    else:
+        st.experimental_rerun()
+
+
 def show(conn, c):
     st.subheader("Registracija")
-    email = st.text_input("El. paštas")
-    password = st.text_input("Slaptažodis", type="password")
-    vardas = st.text_input("Vardas")
-    pavarde = st.text_input("Pavardė")
-    pareigybe = st.text_input("Pareigybė")
-    imone = st.text_input("Įmonė")
+    email = st.text_input("El. paštas", key="reg_email")
+    password = st.text_input("Slaptažodis", type="password", key="reg_password")
+    vardas = st.text_input("Vardas", key="reg_vardas")
+    pavarde = st.text_input("Pavardė", key="reg_pavarde")
+    pareigybe = st.text_input("Pareigybė", key="reg_pareigybe")
+    imone = st.text_input("Įmonė", key="reg_imone")
 
     if st.button("Pateikti paraišką"):
         if not email or not password:
@@ -33,3 +40,15 @@ def show(conn, c):
                 )
                 conn.commit()
                 st.success("Registracija pateikta. Palaukite administratoriaus patvirtinimo.")
+                for key in [
+                    "reg_email",
+                    "reg_password",
+                    "reg_vardas",
+                    "reg_pavarde",
+                    "reg_pareigybe",
+                    "reg_imone",
+                ]:
+                    st.session_state.pop(key, None)
+                st.session_state.show_register = False
+                rerun()
+

--- a/modules/user_admin.py
+++ b/modules/user_admin.py
@@ -59,21 +59,26 @@ def show(conn, c):
                 cols[0].write(user_display)
 
             if cols[1].button("Patvirtinti", key=f"approve_{row['id']}"):
-                c.execute("UPDATE users SET aktyvus = 1 WHERE id = ?", (row['id'],))
-                conn.commit()
-                login.assign_role(conn, c, row['id'], Role.USER)
-                c.execute(
-                    "INSERT INTO darbuotojai (vardas, pavarde, pareigybe, el_pastas, imone, aktyvus) VALUES (?,?,?,?,?,1)",
-                    (
-                        row.get('vardas'),
-                        row.get('pavarde'),
-                        row.get('pareigybe'),
-                        row['username'],
-                        row.get('imone'),
-                    ),
-                )
-                conn.commit()
-                rerun()
+                if warn:
+                    st.error(
+                        "Vartotojo el. pašto domenas nesutampa su įmonės domenu."
+                    )
+                else:
+                    c.execute("UPDATE users SET aktyvus = 1 WHERE id = ?", (row['id'],))
+                    conn.commit()
+                    login.assign_role(conn, c, row['id'], Role.USER)
+                    c.execute(
+                        "INSERT INTO darbuotojai (vardas, pavarde, pareigybe, el_pastas, imone, aktyvus) VALUES (?,?,?,?,?,1)",
+                        (
+                            row.get('vardas'),
+                            row.get('pavarde'),
+                            row.get('pareigybe'),
+                            row['username'],
+                            row.get('imone'),
+                        ),
+                    )
+                    conn.commit()
+                    rerun()
             col_index = 2
             if is_admin:
                 if cols[2].button("Patvirtinti kaip adminą", key=f"approve_admin_{row['id']}"):


### PR DESCRIPTION
## Summary
- reset registration form fields after successful submission and return to login
- only allow company admins to approve users with matching email domains

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68606971fe988324bf0f476a68495d4d