### PR TITLE
Prevent admin approval with mismatched domain

### DIFF
--- a/modules/user_admin.py
+++ b/modules/user_admin.py
@@ -98,21 +98,26 @@ def show(conn, c):
             col_index = 2
             if is_admin:
                 if cols[2].button("Patvirtinti kaip adminą", key=f"approve_admin_{row['id']}"):
-                    c.execute("UPDATE users SET aktyvus = 1 WHERE id = ?", (row['id'],))
-                    conn.commit()
-                    login.assign_role(conn, c, row['id'], Role.COMPANY_ADMIN)
-                    c.execute(
-                        "INSERT INTO darbuotojai (vardas, pavarde, pareigybe, el_pastas, imone, aktyvus) VALUES (?,?,?,?,?,1)",
-                        (
-                            row.get('vardas'),
-                            row.get('pavarde'),
-                            row.get('pareigybe'),
-                            row['username'],
-                            row.get('imone'),
-                        ),
-                    )
-                    conn.commit()
-                    rerun()
+                    if warn:
+                        st.error(
+                            "Vartotojo el. pašto domenas nesutampa su įmonės domenu."
+                        )
+                    else:
+                        c.execute("UPDATE users SET aktyvus = 1 WHERE id = ?", (row['id'],))
+                        conn.commit()
+                        login.assign_role(conn, c, row['id'], Role.COMPANY_ADMIN)
+                        c.execute(
+                            "INSERT INTO darbuotojai (vardas, pavarde, pareigybe, el_pastas, imone, aktyvus) VALUES (?,?,?,?,?,1)",
+                            (
+                                row.get('vardas'),
+                                row.get('pavarde'),
+                                row.get('pareigybe'),
+                                row['username'],
+                                row.get('imone'),
+                            ),
+                        )
+                        conn.commit()
+                        rerun()
                 col_index = 3
             if cols[col_index].button("Šalinti", key=f"delete_{row['id']}"):
                 c.execute("DELETE FROM users WHERE id = ?", (row['id'],))


### PR DESCRIPTION
## Summary
- enforce domain validation when approving a new company admin

## Testing
- `pytest -q` *(fails: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68606fb65d948324981865751add2242