### PR TITLE
Add company variable for filtered queries

### DIFF
--- a/modules/planavimas.py
+++ b/modules/planavimas.py
@@ -9,6 +9,7 @@ from .roles import Role
 def show(conn, c):
     st.title("Planavimas")
     is_admin = login.has_role(conn, c, Role.ADMIN)
+    company = st.session_state.get("imone")
 
     # ==============================
     # 0) Patikriname, ar lentelėje "kroviniai" yra reikiami stulpeliai.
@@ -57,7 +58,7 @@ def show(conn, c):
     else:
         c.execute(
             "SELECT id, numeris, pavadinimas FROM grupes WHERE imone = ? ORDER BY numeris",
-            (st.session_state.get('imone'),)
+            (company,)
         )
         grupes = c.fetchall()  # [(id, numeris, pavadinimas), ...]
 
@@ -86,7 +87,7 @@ def show(conn, c):
     else:
         c.execute(
             "SELECT numeris, priekaba, vadybininkas FROM vilkikai WHERE imone = ? ORDER BY numeris",
-            (st.session_state.get('imone'),)
+            (company,)
         )
         vilkikai_rows = c.fetchall()
     priekaba_map = {row[0]: (row[1] or "") for row in vilkikai_rows}
@@ -111,7 +112,7 @@ def show(conn, c):
     params = [start_str, end_str]
     if not is_admin:
         query += " AND imone = ?"
-        params.append(st.session_state.get('imone'))
+        params.append(company)
     query += " ORDER BY vilkikas, date(iskrovimo_data)"
     df = pd.read_sql_query(query, conn, params=params)
 

--- a/modules/update.py
+++ b/modules/update.py
@@ -83,6 +83,7 @@ def relative_time(created_str):
 def show(conn, c):
     st.title("Padėties atnaujinimai")
     is_admin = login.has_role(conn, c, Role.ADMIN)
+    company = st.session_state.get("imone")
 
     # ==============================
     # 1) Užtikriname, kad lentelėje "vilkiku_darbo_laikai" būtų visi stulpeliai
@@ -119,7 +120,7 @@ def show(conn, c):
     vad_params = ()
     if not is_admin:
         vad_query += " AND imone = ?"
-        vad_params = (st.session_state.get('imone'),)
+        vad_params = (company,)
     vadybininkai = [r[0] for r in c.execute(vad_query, vad_params).fetchall()]
 
     # Gauname grupių sąrašą pagal 'numeris' (ne pavadinimą!), nes darbuotojų lentelėje grupe = numeris
@@ -130,7 +131,7 @@ def show(conn, c):
             r[0]
             for r in c.execute(
                 "SELECT numeris FROM grupes WHERE imone = ?",
-                (st.session_state.get('imone'),),
+                (company,),
             ).fetchall()
         ]
 
@@ -151,7 +152,7 @@ def show(conn, c):
     params = ()
     if not is_admin:
         vilk_query += " WHERE v.imone = ?"
-        params = (st.session_state.get('imone'),)
+        params = (company,)
     vilkikai_info = c.execute(vilk_query, params).fetchall()
 
     vilkikai = []
@@ -160,7 +161,7 @@ def show(conn, c):
         if vadyb and c.execute(
             "SELECT vadybininkas FROM vilkikai WHERE numeris = ?"{}
             .format("" if is_admin else " AND imone = ?"),
-            (numeris,) if is_admin else (numeris, st.session_state.get('imone')),
+            (numeris,) if is_admin else (numeris, company),
         ).fetchone()[0] != vadyb:
             continue
         # Filtruojame pagal grupę (darbuotojų lentelėje saugomas 'grupe' = grupės numeris)
@@ -193,7 +194,7 @@ def show(conn, c):
     params = list(vilkikai) + [str(today)]
     if not is_admin:
         query += " AND imone = ?"
-        params.append(st.session_state.get('imone'))
+        params.append(company)
     query += " ORDER BY vilkikas ASC, pakrovimo_data ASC"
     kroviniai = c.execute(query, params).fetchall()
 
@@ -210,7 +211,7 @@ def show(conn, c):
     params = ()
     if not is_admin:
         vilk_gr_query += " WHERE v.imone = ?"
-        params = (st.session_state.get('imone'),)
+        params = (company,)
     vilk_grupes = dict(c.execute(vilk_gr_query, params).fetchall())
 
     eksp_gr_query = """
@@ -222,7 +223,7 @@ def show(conn, c):
     params2 = ()
     if not is_admin:
         eksp_gr_query += " WHERE k.imone = ?"
-        params2 = (st.session_state.get('imone'),)
+        params2 = (company,)
     eksp_grupes = dict(c.execute(eksp_gr_query, params2).fetchall())
 
     # ==============================
@@ -448,7 +449,7 @@ def show(conn, c):
                     c.execute(
                         "SELECT vadybininkas FROM vilkikai WHERE numeris = ?"{}
                         .format("" if is_admin else " AND imone = ?"),
-                        (k[5],) if is_admin else (k[5], st.session_state.get('imone')),
+                        (k[5],) if is_admin else (k[5], company),
                     ).fetchone()[0],
                     eksp_vad,
                     "", "",
@@ -471,7 +472,7 @@ def show(conn, c):
                     c.execute(
                         "SELECT vadybininkas FROM vilkikai WHERE numeris = ?"{}
                         .format("" if is_admin else " AND imone = ?"),
-                        (k[5],) if is_admin else (k[5], st.session_state.get('imone')),
+                        (k[5],) if is_admin else (k[5], company),
                     ).fetchone()[0],
                     eksp_vad,
                     "", ""


### PR DESCRIPTION
## Summary
- refactor planavimas and update modules to store `imone` session value
- use that variable for filtering queries

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6860f6838ed88324892c1682c518af72