### PR TITLE
Fix query syntax causing Streamlit startup crash

### DIFF
--- a/modules/update.py
+++ b/modules/update.py
@@ -159,8 +159,8 @@ def show(conn, c):
     for numeris, gr in vilkikai_info:
         # Filtruojame pagal vadybininką, jei pasirinktas
         if vadyb and c.execute(
-            "SELECT vadybininkas FROM vilkikai WHERE numeris = ?"{}
-            .format("" if is_admin else " AND imone = ?"),
+            "SELECT vadybininkas FROM vilkikai WHERE numeris = ?"
+            + ("" if is_admin else " AND imone = ?"),
             (numeris,) if is_admin else (numeris, company),
         ).fetchone()[0] != vadyb:
             continue
@@ -447,8 +447,8 @@ def show(conn, c):
                     ikr_status_in, ikr_laikas_in, formatted_ikr_date,
                     komentaras_in,
                     c.execute(
-                        "SELECT vadybininkas FROM vilkikai WHERE numeris = ?"{}
-                        .format("" if is_admin else " AND imone = ?"),
+                        "SELECT vadybininkas FROM vilkikai WHERE numeris = ?"
+                        + ("" if is_admin else " AND imone = ?"),
                         (k[5],) if is_admin else (k[5], company),
                     ).fetchone()[0],
                     eksp_vad,
@@ -470,8 +470,8 @@ def show(conn, c):
                     ikr_status_in, ikr_laikas_in, formatted_ikr_date,
                     komentaras_in,
                     c.execute(
-                        "SELECT vadybininkas FROM vilkikai WHERE numeris = ?"{}
-                        .format("" if is_admin else " AND imone = ?"),
+                        "SELECT vadybininkas FROM vilkikai WHERE numeris = ?"
+                        + ("" if is_admin else " AND imone = ?"),
                         (k[5],) if is_admin else (k[5], company),
                     ).fetchone()[0],
                     eksp_vad,


### PR DESCRIPTION
## Summary
- correct SQL query strings in `modules/update.py` that previously caused `SyntaxError`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for 'fastapi' and 'db')*

------
https://chatgpt.com/codex/tasks/task_e_6860f7f8135c83249eaa453166d239dc