### PR TITLE
Add EU country dropdown and rename orders module

### DIFF
--- a/main.py
+++ b/main.py
@@ -41,7 +41,7 @@ if "user_id" not in st.session_state:
 
 # 5) Horizontalus meniu
 module_functions = {
-    "Kroviniai": kroviniai.show,
+    "Užsakymai": kroviniai.show,
     "Vilkikai": vilkikai.show,
     "Priekabos": priekabos.show,
     "Grupės": grupes.show,

--- a/modules/constants.py
+++ b/modules/constants.py
@@ -1,0 +1,20 @@
+# Shared constants and helpers
+
+# List of European countries (name, ISO code)
+EU_COUNTRIES = [
+    ("", ""),
+    ("Lietuva", "LT"), ("Baltarusija", "BY"), ("Latvija", "LV"), ("Lenkija", "PL"), ("Vokietija", "DE"),
+    ("Prancūzija", "FR"), ("Ispanija", "ES"), ("Italija", "IT"), ("Olandija", "NL"), ("Belgija", "BE"),
+    ("Austrija", "AT"), ("Švedija", "SE"), ("Suomija", "FI"), ("Čekija", "CZ"), ("Slovakija", "SK"),
+    ("Vengrija", "HU"), ("Rumunija", "RO"), ("Bulgarija", "BG"), ("Danija", "DK"), ("Norvegija", "NO"),
+    ("Šveicarija", "CH"), ("Kroatija", "HR"), ("Slovėnija", "SI"), ("Portugalija", "PT"), ("Graikija", "GR"),
+    ("Airija", "IE"), ("Didžioji Britanija", "GB"),
+]
+
+
+def country_flag(code: str) -> str:
+    """Return emoji flag for ISO country code."""
+    if not code or len(code) != 2:
+        return ""
+    offset = 127397
+    return chr(ord(code[0].upper()) + offset) + chr(ord(code[1].upper()) + offset)

--- a/modules/klientai.py
+++ b/modules/klientai.py
@@ -2,6 +2,7 @@ import streamlit as st
 import pandas as pd
 from . import login
 from .roles import Role
+from .constants import EU_COUNTRIES, country_flag
 
 def show(conn, c):
     # 1. Užtikrinti, kad egzistuotų reikiami stulpeliai
@@ -161,10 +162,19 @@ def show(conn, c):
             value=("" if is_new else cli.get("kontaktinis_tel", "")),
             key="kontaktinis_tel"
         )
-        salis = col1.text_input(
+        country_map = {name: code for name, code in EU_COUNTRIES}
+        country_names = list(country_map.keys())
+        salis_default = "" if is_new else cli.get("salis", "")
+        try:
+            salis_index = country_names.index(salis_default)
+        except ValueError:
+            salis_index = 0
+        salis = col1.selectbox(
             "Šalis",
-            value=("" if is_new else cli.get("salis", "")),
-            key="salis"
+            country_names,
+            index=salis_index,
+            key="salis",
+            format_func=lambda n: f"{country_flag(country_map.get(n, ''))} {n}" if n else "",
         )
         regionas = col1.text_input(
             "Regionas",

--- a/modules/kroviniai.py
+++ b/modules/kroviniai.py
@@ -3,15 +3,7 @@ import pandas as pd
 from datetime import date, time, timedelta
 from . import login
 from .roles import Role
-
-EU_COUNTRIES = [
-    ("", ""), ("Lietuva", "LT"), ("Baltarusija", "BY"), ("Latvija", "LV"), ("Lenkija", "PL"), ("Vokietija", "DE"),
-    ("Prancūzija", "FR"), ("Ispanija", "ES"), ("Italija", "IT"), ("Olandija", "NL"), ("Belgija", "BE"),
-    ("Austrija", "AT"), ("Švedija", "SE"), ("Suomija", "FI"), ("Čekija", "CZ"), ("Slovakija", "SK"),
-    ("Vengrija", "HU"), ("Rumunija", "RO"), ("Bulgarija", "BG"), ("Danija", "DK"), ("Norvegija", "NO"),
-    ("Šveicarija", "CH"), ("Kroatija", "HR"), ("Slovėnija", "SI"), ("Portugalija", "PT"), ("Graikija", "GR"),
-    ("Airija", "IE"), ("Didžioji Britanija", "GB"),
-]
+from .constants import EU_COUNTRIES, country_flag
 
 HEADER_LABELS = {
     "id": "ID",
@@ -299,7 +291,11 @@ def show(conn, c):
             value=(date.today() if is_new else pd.to_datetime(data['pakrovimo_data']).date()),
             key="pk_data"
         )
-        pk_salis_opts = [f"{n} ({c})" for n, c in EU_COUNTRIES]
+        pk_salis_opts = [
+            f"{country_flag(c)} {n} ({c})".strip()
+            if c else ""
+            for n, c in EU_COUNTRIES
+        ]
         pk_salis_index = 0
         if not is_new:
             try:


### PR DESCRIPTION
## Summary
- include constants for European countries and flags
- show country dropdown with flags in Clients form
- display flags for pickup/delivery countries in orders module
- rename **Kroviniai** module to **Užsakymai**

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68612e54ca0c83248802bc30c54a309c