### PR TITLE
Fix syntax error in priekabos module

### DIFF
--- a/modules/priekabos.py
+++ b/modules/priekabos.py
@@ -159,11 +159,18 @@ def show(conn, c):
                             tech.isoformat(),
                             draud_date.isoformat(),
                             st.session_state.get('imone')
+                        ),
                     )
-                )
-                conn.commit()
-                log_action(conn, c, st.session_state.get('user_id'), 'insert', 'priekabos', c.lastrowid)
-                st.success("✅ Priekaba įrašyta.")
+                    conn.commit()
+                    log_action(
+                        conn,
+                        c,
+                        st.session_state.get('user_id'),
+                        'insert',
+                        'priekabos',
+                        c.lastrowid,
+                    )
+                    st.success("✅ Priekaba įrašyta.")
                     clear_sel()
                 except Exception as e:
                     st.error(f"❌ Klaida: {e}")


### PR DESCRIPTION
## Summary
- fix indentation and parenthesis in `modules/priekabos.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi', ModuleNotFoundError: No module named 'db')*

------
https://chatgpt.com/codex/tasks/task_e_686139dfdf1083248fe6b031bb84e449