### PR TITLE
Add decorative header lines

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,7 +14,16 @@ st.markdown("""
 </style>
 """, unsafe_allow_html=True)
 
-# 3) Inicializuojame DB – lentelės sukuriamos funkcijoje init_db()
+# 3) Dekoratyvinės juostos puslapio viršuje
+st.markdown(
+    """
+    <div style='height:1mm; width:100%; background-color: orange;'></div>
+    <div style='height:1mm; width:100%; background-color: black;'></div>
+    <div style='height:1mm; width:100%; background-color: violet;'></div>
+    """,
+    unsafe_allow_html=True,
+)
+# 4) Inicializuojame DB – lentelės sukuriamos funkcijoje init_db()
 from db import init_db
 conn, c = init_db()    # naudos failą „main.db“
 


### PR DESCRIPTION
## Summary
- decorate Streamlit app with orange, black and violet lines at the top

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68613d80b3548324a8847c6914340007