### PR TITLE
Ensure decorative stripes always visible above sidebar

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ from modules.roles import Role
 # 1) Puslapio nustatymai
 st.set_page_config(layout="wide")
 
-# 2) Minimalus CSS (radio bar lieka viršuje)
+# 2) Minimalus CSS (radio bar lieka viršuje, dekoratyvinės juostos visada matomos)
 st.markdown(
     """
 <style>
@@ -16,7 +16,7 @@ st.markdown(
     top: 0;
     left: 0;
     width: 100%;
-    z-index: 100000; /* keep stripes above sidebar */
+    z-index: 100000; /* keep stripes above sidebar and login menu */
   }
   .stRadio > div          { height: 1cm !important; margin-top: 0 !important; }
   .stRadio > div > label > div { padding-top: 0 !important; padding-bottom: 0 !important; }


### PR DESCRIPTION
## Summary
- clarify CSS comment about `z-index` for `.top-stripes`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686143a4725c83249444dfb364302df4