### PR TITLE
Fix trailer assignment state and improve auditing

### DIFF
--- a/modules/login.py
+++ b/modules/login.py
@@ -43,9 +43,10 @@ def verify_user(conn, c, username: str, password: str):
     row = c.fetchone()
     if row and bcrypt.checkpw(password.encode(), row[1].encode()):
         from datetime import datetime
+        ts = datetime.utcnow().replace(second=0, microsecond=0).isoformat(timespec="minutes")
         c.execute(
             "UPDATE users SET last_login = ? WHERE id = ?",
-            (datetime.utcnow().isoformat(), row[0]),
+            (ts, row[0]),
         )
         conn.commit()
         return row[0], row[2]

--- a/modules/priekabos.py
+++ b/modules/priekabos.py
@@ -124,6 +124,7 @@ def show(conn, c):
                 log_action(conn, c, st.session_state.get('user_id'), 'update', 'priekabos', sel)
                 st.success("✅ Pakeitimai išsaugoti.")
                 clear_sel()
+                st.experimental_rerun()
             except Exception as e:
                 st.error(f"❌ Klaida: {e}")
         return
@@ -172,6 +173,7 @@ def show(conn, c):
                     )
                     st.success("✅ Priekaba įrašyta.")
                     clear_sel()
+                    st.experimental_rerun()
                 except Exception as e:
                     st.error(f"❌ Klaida: {e}")
         return

--- a/modules/update.py
+++ b/modules/update.py
@@ -428,7 +428,7 @@ def show(conn, c):
             jau_irasas = c.execute("""
                 SELECT id FROM vilkiku_darbo_laikai WHERE vilkiko_numeris = ? AND data = ?
             """, (k[5], k[3])).fetchone()
-            now_str = datetime.now().isoformat()
+            now_str = datetime.now().replace(second=0, microsecond=0).isoformat(timespec="minutes")
             formatted_pk_date = pk_data_in.isoformat()
             formatted_ikr_date = ikr_data_in.isoformat()
 

--- a/modules/vilkikai.py
+++ b/modules/vilkikai.py
@@ -125,6 +125,7 @@ def show(conn, c):
             conn.commit()
             st.success("✅ Priekabos paskirstymas sėkmingai atnaujintas.")
             clear_selection()
+            st.experimental_rerun()
 
         # 6.2) Mygtukas „Pridėti naują vilkiką“
         st.button("➕ Pridėti naują vilkiką", on_click=new_vilk, use_container_width=True)
@@ -415,6 +416,7 @@ def show(conn, c):
                 if draud_date:
                     st.info(f"🛡️ Dienų iki draudimo pabaigos liko: {(draud_date - date.today()).days}")
                 clear_selection()
+                st.experimental_rerun()
             except Exception as e:
                 st.error(f"❌ Klaida saugant: {e}")
 


### PR DESCRIPTION
## Summary
- make audit timestamps minute-precision and show details
- record last login with minutes precision
- return to list view after saving trailers or trucks
- round update timestamps to minutes
- rerun page after trailer assignments

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68617c88f0ac8324953c11ac3b64b863