### PR TITLE
Fix compatibility with new Streamlit rerun API

### DIFF
--- a/modules/login.py
+++ b/modules/login.py
@@ -1,11 +1,6 @@
 import streamlit as st
 
-
-def rerun():
-    if hasattr(st, "rerun"):
-        st.rerun()
-    else:
-        st.experimental_rerun()
+from .utils import rerun
 
 from .auth_utils import hash_password
 from .roles import Role

--- a/modules/priekabos.py
+++ b/modules/priekabos.py
@@ -2,6 +2,7 @@ import streamlit as st
 import pandas as pd
 from datetime import date
 from .audit import log_action
+from .utils import rerun
 
 def show(conn, c):
     st.title("Priekabų valdymas")
@@ -124,7 +125,7 @@ def show(conn, c):
                 log_action(conn, c, st.session_state.get('user_id'), 'update', 'priekabos', sel)
                 st.success("✅ Pakeitimai išsaugoti.")
                 clear_sel()
-                st.experimental_rerun()
+                rerun()
             except Exception as e:
                 st.error(f"❌ Klaida: {e}")
         return
@@ -173,7 +174,7 @@ def show(conn, c):
                     )
                     st.success("✅ Priekaba įrašyta.")
                     clear_sel()
-                    st.experimental_rerun()
+                    rerun()
                 except Exception as e:
                     st.error(f"❌ Klaida: {e}")
         return

--- a/modules/register.py
+++ b/modules/register.py
@@ -2,13 +2,7 @@ import streamlit as st
 
 from .auth_utils import hash_password
 from .audit import log_action
-
-
-def rerun():
-    if hasattr(st, "rerun"):
-        st.rerun()
-    else:
-        st.experimental_rerun()
+from .utils import rerun
 
 
 def show(conn, c):

--- a/modules/user_admin.py
+++ b/modules/user_admin.py
@@ -3,13 +3,7 @@ import pandas as pd
 from . import login
 from .roles import Role
 from .audit import log_action
-
-
-def rerun():
-    if hasattr(st, "rerun"):
-        st.rerun()
-    else:
-        st.experimental_rerun()
+from .utils import rerun
 
 
 def show(conn, c):

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -1,0 +1,10 @@
+import streamlit as st
+
+
+def rerun() -> None:
+    """Rerun the Streamlit app in a version-compatible way."""
+    if hasattr(st, "rerun"):
+        st.rerun()
+    else:
+        # Fallback for older Streamlit versions
+        st.experimental_rerun()

--- a/modules/vilkikai.py
+++ b/modules/vilkikai.py
@@ -3,6 +3,7 @@ import pandas as pd
 from datetime import date
 from . import login
 from .roles import Role
+from .utils import rerun
 
 def show(conn, c):
     # 1) Užtikriname, kad lentelėje „vilkikai“ būtų visi reikalingi stulpeliai
@@ -125,7 +126,7 @@ def show(conn, c):
             conn.commit()
             st.success("✅ Priekabos paskirstymas sėkmingai atnaujintas.")
             clear_selection()
-            st.experimental_rerun()
+            rerun()
 
         # 6.2) Mygtukas „Pridėti naują vilkiką“
         st.button("➕ Pridėti naują vilkiką", on_click=new_vilk, use_container_width=True)
@@ -416,7 +417,7 @@ def show(conn, c):
                 if draud_date:
                     st.info(f"🛡️ Dienų iki draudimo pabaigos liko: {(draud_date - date.today()).days}")
                 clear_selection()
-                st.experimental_rerun()
+                rerun()
             except Exception as e:
                 st.error(f"❌ Klaida saugant: {e}")
 


### PR DESCRIPTION
## Summary
- add a small helper `rerun` for Streamlit
- replace direct `st.experimental_rerun` calls with the helper
- re-use the helper in login, register and user admin modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6861832583848324969d1bc73199fbf0