### PR TITLE
Fix employee form errors and rerun after saves

### DIFF
--- a/modules/darbuotojai.py
+++ b/modules/darbuotojai.py
@@ -3,6 +3,7 @@ import pandas as pd
 from . import login
 from .roles import Role
 from .audit import log_action
+from .utils import rerun
 
 def show(conn, c):
     # Užtikrinti, kad egzistuotų stulpelis „aktyvus“ darbuotojų lentelėje
@@ -128,9 +129,15 @@ def show(conn, c):
         default_pareigybe = pareigybes[0]
     else:
         default_pareigybe = emp_data.get("pareigybe", pareigybes[0])
+
+    try:
+        idx = pareigybes.index(default_pareigybe)
+    except ValueError:
+        idx = 0
+
     selected_pareigybe = cols1[2].selectbox(
         "Pareigybė", pareigybes, key="pareigybe",
-        index=pareigybes.index(default_pareigybe)
+        index=idx
     )
 
     # 4) El. paštas
@@ -155,10 +162,17 @@ def show(conn, c):
     else:
         default_grupe = emp_data.get("grupe", galimos_grupes[0] if galimos_grupes else "")
 
-    cols2[2].selectbox(
-        "Grupė", galimos_grupes, key="grupe",
-        index=galimos_grupes.index(default_grupe) if default_grupe in galimos_grupes else 0
-    )
+    try:
+        gr_idx = galimos_grupes.index(default_grupe)
+    except ValueError:
+        gr_idx = 0
+
+    if not galimos_grupes:
+        cols2[2].selectbox("Grupė", [""], index=0, key="grupe")
+    else:
+        cols2[2].selectbox(
+            "Grupė", galimos_grupes, key="grupe", index=gr_idx
+        )
 
     # 7) Aktyvumo statusas – checkbox
     if is_new:
@@ -198,6 +212,7 @@ def show(conn, c):
         log_action(conn, c, st.session_state.get('user_id'), action, 'darbuotojai', rec_id)
         st.success("✅ Duomenys įrašyti.")
         clear_selection()
+        rerun()
 
     btn_save, btn_back = st.columns(2)
     btn_save.button("💾 Išsaugoti darbuotoją", on_click=do_save)

--- a/modules/klientai.py
+++ b/modules/klientai.py
@@ -3,6 +3,7 @@ import pandas as pd
 from . import login
 from .roles import Role
 from .constants import EU_COUNTRIES, country_flag
+from .utils import rerun
 
 def show(conn, c):
     # 1. Užtikrinti, kad egzistuotų reikiami stulpeliai
@@ -379,5 +380,6 @@ def show(conn, c):
 
             st.success("✅ Duomenys įrašyti ir limitai atnaujinti visiems su tuo pačiu VAT numeriu.")
             clear_selection()
+            rerun()
         except Exception as e:
             st.error(f"❌ Klaida: {e}")

--- a/modules/kroviniai.py
+++ b/modules/kroviniai.py
@@ -4,6 +4,7 @@ from datetime import date, time, timedelta
 from . import login
 from .roles import Role
 from .constants import EU_COUNTRIES, country_flag
+from .utils import rerun
 
 HEADER_LABELS = {
     "id": "ID",
@@ -587,5 +588,6 @@ def show(conn, c):
 
                 st.success("✅ Krovinys išsaugotas ir limitai atnaujinti.")
                 clear_sel()
+                rerun()
             except Exception as e:
                 st.error(f"❌ Klaida: {e}")

--- a/modules/vairuotojai.py
+++ b/modules/vairuotojai.py
@@ -4,6 +4,7 @@ import pandas as pd
 from datetime import date
 from . import login
 from .roles import Role
+from .utils import rerun
 
 # ---------- Konstantos ----------
 TAUTYBES = [
@@ -124,6 +125,7 @@ def show(conn, c):
                 conn.commit()
                 st.success("✅ Įrašyta.")
                 _clear_sel()
+                rerun()
         return
 
     # --------------------------------------------------- Redagavimas
@@ -213,6 +215,7 @@ def show(conn, c):
             conn.commit()
             st.success("✅ Pakeitimai išsaugoti.")
             _clear_sel()
+            rerun()
         return
 
     # --------------------------------------------------- Sąrašas + FILTRAI


### PR DESCRIPTION
## Summary
- fix default employee role and group selection to avoid ValueError
- automatically rerun after saving drivers, clients, orders and employees

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686185f87454832487f3f935a5d48d08