### PR TITLE
Improve save success handling across modules

### DIFF
--- a/modules/darbuotojai.py
+++ b/modules/darbuotojai.py
@@ -45,6 +45,9 @@ def show(conn, c):
             params = (st.session_state.get("imone"),)
         df = pd.read_sql(query, conn, params=params)
 
+        msg = st.session_state.pop("darbuotojai_msg", None)
+        if msg:
+            st.success(msg)
 
         if df.empty:
             st.info("ℹ️ Nėra darbuotojų.")
@@ -210,9 +213,8 @@ def show(conn, c):
             rec_id = sel
         conn.commit()
         log_action(conn, c, st.session_state.get('user_id'), action, 'darbuotojai', rec_id)
-        st.success("✅ Duomenys įrašyti.")
+        st.session_state.darbuotojai_msg = "✅ Duomenys įrašyti."
         clear_selection()
-        rerun()
 
     btn_save, btn_back = st.columns(2)
     btn_save.button("💾 Išsaugoti darbuotoją", on_click=do_save)

--- a/modules/klientai.py
+++ b/modules/klientai.py
@@ -65,6 +65,10 @@ def show(conn, c):
                 conn,
                 params=(st.session_state.get('imone'),),
             )
+
+        msg = st.session_state.pop('klientai_msg', None)
+        if msg:
+            st.success(msg)
         if df.empty:
             st.info("ℹ️ Nėra klientų.")
             return
@@ -378,7 +382,7 @@ def show(conn, c):
             )
             conn.commit()
 
-            st.success("✅ Duomenys įrašyti ir limitai atnaujinti visiems su tuo pačiu VAT numeriu.")
+            st.session_state.klientai_msg = "✅ Duomenys įrašyti ir limitai atnaujinti visiems su tuo pačiu VAT numeriu."
             clear_selection()
             rerun()
         except Exception as e:

--- a/modules/kroviniai.py
+++ b/modules/kroviniai.py
@@ -194,6 +194,10 @@ def show(conn, c):
                 conn,
                 params=(st.session_state.get('imone'),),
             )
+
+        msg = st.session_state.pop("kroviniai_msg", None)
+        if msg:
+            st.success(msg)
         if df.empty:
             st.info("Kol kas nėra krovinių.")
         else:
@@ -586,7 +590,7 @@ def show(conn, c):
                 )
                 conn.commit()
 
-                st.success("✅ Krovinys išsaugotas ir limitai atnaujinti.")
+                st.session_state.kroviniai_msg = "✅ Krovinys išsaugotas ir limitai atnaujinti."
                 clear_sel()
                 rerun()
             except Exception as e:

--- a/modules/priekabos.py
+++ b/modules/priekabos.py
@@ -123,7 +123,7 @@ def show(conn, c):
                 )
                 conn.commit()
                 log_action(conn, c, st.session_state.get('user_id'), 'update', 'priekabos', sel)
-                st.success("✅ Pakeitimai išsaugoti.")
+                st.session_state.priekabos_msg = "✅ Pakeitimai išsaugoti."
                 clear_sel()
                 rerun()
             except Exception as e:
@@ -172,7 +172,7 @@ def show(conn, c):
                         'priekabos',
                         c.lastrowid,
                     )
-                    st.success("✅ Priekaba įrašyta.")
+                    st.session_state.priekabos_msg = "✅ Priekaba įrašyta."
                     clear_sel()
                     rerun()
                 except Exception as e:
@@ -185,6 +185,9 @@ def show(conn, c):
         conn,
         params=(st.session_state.get('imone'),)
     )
+    msg = st.session_state.pop("priekabos_msg", None)
+    if msg:
+        st.success(msg)
     if df.empty:
         st.info("ℹ️ Nėra priekabų.")
         return

--- a/modules/vairuotojai.py
+++ b/modules/vairuotojai.py
@@ -123,7 +123,7 @@ def show(conn, c):
                     ),
                 )
                 conn.commit()
-                st.success("✅ Įrašyta.")
+                st.session_state.vairuotojai_msg = "✅ Įrašyta."
                 _clear_sel()
                 rerun()
         return
@@ -213,7 +213,7 @@ def show(conn, c):
                 ),
             )
             conn.commit()
-            st.success("✅ Pakeitimai išsaugoti.")
+            st.session_state.vairuotojai_msg = "✅ Pakeitimai išsaugoti."
             _clear_sel()
             rerun()
         return
@@ -229,6 +229,10 @@ def show(conn, c):
             conn,
             params=(st.session_state.get('imone'),),
         )
+
+    msg = st.session_state.pop('vairuotojai_msg', None)
+    if msg:
+        st.success(msg)
     df = df.fillna("")
 
     # ---------- Filtrų eilutė ----------

--- a/modules/vilkikai.py
+++ b/modules/vilkikai.py
@@ -124,7 +124,7 @@ def show(conn, c):
                 (prn or "", sel_vilk, st.session_state.get('imone'))
             )
             conn.commit()
-            st.success("✅ Priekabos paskirstymas sėkmingai atnaujintas.")
+            st.session_state.vilkikai_msg = "✅ Priekabos paskirstymas sėkmingai atnaujintas."
             clear_selection()
             rerun()
 
@@ -140,6 +140,12 @@ def show(conn, c):
             query = "SELECT * FROM vilkikai WHERE imone = ? ORDER BY tech_apziura ASC"
             params = (st.session_state.get('imone'),)
         df = pd.read_sql_query(query, conn, params=params)
+
+        msg = st.session_state.pop("vilkikai_msg", None)
+        if msg:
+            for line in msg.split("\n"):
+                st.success(line)
+
         if df.empty:
             st.info("🔍 Kol kas nėra vilkikų.")
             return
@@ -411,11 +417,11 @@ def show(conn, c):
                         )
                     )
                 conn.commit()
-                st.success("✅ Vilkikas išsaugotas sėkmingai.")
+                st.session_state.vilkikai_msg = "✅ Vilkikas išsaugotas sėkmingai."
                 if tech_date:
-                    st.info(f"🔧 Dienų iki tech. apžiūros liko: {(tech_date - date.today()).days}")
+                    st.session_state.vilkikai_msg += f"\n🔧 Dienų iki tech. apžiūros liko: {(tech_date - date.today()).days}"
                 if draud_date:
-                    st.info(f"🛡️ Dienų iki draudimo pabaigos liko: {(draud_date - date.today()).days}")
+                    st.session_state.vilkikai_msg += f"\n🛡️ Dienų iki draudimo pabaigos liko: {(draud_date - date.today()).days}"
                 clear_selection()
                 rerun()
             except Exception as e:


### PR DESCRIPTION
## Summary
- show post-save messages using session state across modules
- avoid `st.rerun()` inside callbacks
- persist success messages when returning to list views

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686189be69d08324b09d180880da6d72