### PR TITLE
Standardize header layout

### DIFF
--- a/modules/darbuotojai.py
+++ b/modules/darbuotojai.py
@@ -3,7 +3,7 @@ import pandas as pd
 from . import login
 from .roles import Role
 from .audit import log_action
-from .utils import rerun
+from .utils import rerun, title_with_add
 
 def show(conn, c):
     # Užtikrinti, kad egzistuotų stulpelis „aktyvus“ darbuotojų lentelėje
@@ -25,10 +25,8 @@ def show(conn, c):
     def start_edit(emp_id):
         st.session_state.selected_emp = emp_id
 
-    # Antraštė + „Pridėti naują darbuotoją“ mygtukas
-    title_col, add_col = st.columns([9, 1])
-    title_col.title("Darbuotojai")
-    add_col.button("➕ Pridėti naują darbuotoją", on_click=start_new, use_container_width=True)
+    # Antraštė ir mygtukas naujam įrašui
+    title_with_add("Darbuotojai", "➕ Pridėti naują darbuotoją", on_click=start_new)
 
     # Inicializuojame būseną
     if 'selected_emp' not in st.session_state:

--- a/modules/grupes.py
+++ b/modules/grupes.py
@@ -4,9 +4,9 @@ import streamlit as st
 import pandas as pd
 from . import login
 from .roles import Role
+from .utils import title_with_add
 
 def show(conn, c):
-    st.title("Grupės")
 
     # 1) Užtikrinti, kad egzistuotų lentelė „grupes“
     c.execute("""
@@ -48,7 +48,7 @@ def show(conn, c):
     if "show_add_form" not in st.session_state:
         st.session_state["show_add_form"] = False
 
-    if st.button("➕ Pridėti grupę"):
+    if title_with_add("Grupės", "➕ Pridėti grupę"):
         st.session_state["show_add_form"] = True
 
     # 5) Jei paspausta „Pridėti grupę“, atvaizduoti formą

--- a/modules/klientai.py
+++ b/modules/klientai.py
@@ -3,7 +3,7 @@ import pandas as pd
 from . import login
 from .roles import Role
 from .constants import EU_COUNTRIES, country_flag
-from .utils import rerun
+from .utils import rerun, title_with_add
 
 def show(conn, c):
     # 1. Užtikrinti, kad egzistuotų reikiami stulpeliai
@@ -43,9 +43,7 @@ def show(conn, c):
         st.session_state.selected_client = cid
 
     # 2. Antraštė + „Pridėti naują klientą“ mygtukas
-    title_col, add_col = st.columns([9, 1])
-    title_col.title("Klientai")
-    add_col.button("➕ Pridėti naują klientą", on_click=start_new)
+    title_with_add("Klientai", "➕ Pridėti naują klientą", on_click=start_new)
 
     # 3. Būsenos inicializavimas
     if 'selected_client' not in st.session_state:

--- a/modules/kroviniai.py
+++ b/modules/kroviniai.py
@@ -4,7 +4,7 @@ from datetime import date, time, timedelta
 from . import login
 from .roles import Role
 from .constants import EU_COUNTRIES, country_flag
-from .utils import rerun
+from .utils import rerun, title_with_add
 
 HEADER_LABELS = {
     "id": "ID",
@@ -69,9 +69,11 @@ def get_vieta(salis, regionas):
     return f"{salis}{regionas or ''}"
 
 def show(conn, c):
-    st.title("Užsakymų valdymas")
     is_admin = login.has_role(conn, c, Role.ADMIN)
-    add_clicked = st.button("➕ Pridėti naują krovinį", use_container_width=True)
+    add_clicked = title_with_add(
+        "Užsakymų valdymas",
+        "➕ Pridėti naują krovinį",
+    )
 
     # Įsitikinti, kad visi stulpeliai egzistuoja lentelėje 'kroviniai'
     expected = {

--- a/modules/priekabos.py
+++ b/modules/priekabos.py
@@ -2,10 +2,9 @@ import streamlit as st
 import pandas as pd
 from datetime import date
 from .audit import log_action
-from .utils import rerun
+from .utils import rerun, title_with_add
 
 def show(conn, c):
-    st.title("Priekabų valdymas")
 
     # 1) Užtikriname, kad lentelėje 'priekabos' egzistuotų visi reikalingi stulpeliai
     existing = [r[1] for r in c.execute("PRAGMA table_info(priekabos)").fetchall()]
@@ -50,8 +49,8 @@ def show(conn, c):
     def edit(id):
         st.session_state.selected_priek = id
 
-    # 4) "Pridėti priekabą" mygtukas viršuje
-    st.button("➕ Pridėti priekabą", on_click=new, use_container_width=True)
+    # 4) Antraštė ir mygtukas naujai priekabai
+    title_with_add("Priekabų valdymas", "➕ Pridėti priekabą", on_click=new)
 
     sel = st.session_state.selected_priek
 

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -8,3 +8,10 @@ def rerun() -> None:
     else:
         # Fallback for older Streamlit versions
         st.experimental_rerun()
+
+
+def title_with_add(title: str, button_label: str, on_click=None):
+    """Display a page title with an aligned "add" button."""
+    left, right = st.columns([9, 1])
+    left.title(title)
+    return right.button(button_label, on_click=on_click, use_container_width=True)

--- a/modules/vairuotojai.py
+++ b/modules/vairuotojai.py
@@ -4,7 +4,7 @@ import pandas as pd
 from datetime import date
 from . import login
 from .roles import Role
-from .utils import rerun
+from .utils import rerun, title_with_add
 
 # ---------- Konstantos ----------
 TAUTYBES = [
@@ -61,7 +61,6 @@ def _text_filter(field, placeholder):
 
 # ---------- Main ----------
 def show(conn, c):
-    st.title("Vairuotojų valdymas")
     _ensure_columns(c, conn)
     is_admin = login.has_role(conn, c, Role.ADMIN)
 
@@ -77,6 +76,8 @@ def show(conn, c):
 
     def _edit_vair(v_id):
         st.session_state.selected_vair = v_id
+
+    title_with_add("Vairuotojų valdymas", "➕ Pridėti vairuotoją", on_click=_new_vair)
 
     sel = st.session_state.selected_vair
     drv2vilk = _driver_to_vilkik_map(c, is_admin)
@@ -219,7 +220,6 @@ def show(conn, c):
         return
 
     # --------------------------------------------------- Sąrašas + FILTRAI
-    st.button("➕ Pridėti vairuotoją", on_click=_new_vair, use_container_width=True)
 
     if is_admin:
         df = pd.read_sql_query("SELECT * FROM vairuotojai", conn)

--- a/modules/vilkikai.py
+++ b/modules/vilkikai.py
@@ -3,7 +3,7 @@ import pandas as pd
 from datetime import date
 from . import login
 from .roles import Role
-from .utils import rerun
+from .utils import rerun, title_with_add
 
 def show(conn, c):
     # 1) Užtikriname, kad lentelėje „vilkikai“ būtų visi reikalingi stulpeliai
@@ -56,8 +56,8 @@ def show(conn, c):
     def edit_vilk(numeris):
         st.session_state.selected_vilk = numeris
 
-    # 4) Antraštė
-    st.title("Vilkikų valdymas")
+    # 4) Antraštė ir mygtukas naujam įrašui
+    title_with_add("Vilkikų valdymas", "➕ Pridėti naują vilkiką", on_click=new_vilk)
 
     # 5) Inicializuojame sesijos būseną jei neapibrėžta
     if 'selected_vilk' not in st.session_state:
@@ -128,10 +128,7 @@ def show(conn, c):
             clear_selection()
             rerun()
 
-        # 6.2) Mygtukas „Pridėti naują vilkiką“
-        st.button("➕ Pridėti naują vilkiką", on_click=new_vilk, use_container_width=True)
-
-        # 6.3) Vilkikų sąrašo atvaizdavimas
+        # 6.2) Vilkikų sąrašo atvaizdavimas
         is_admin = login.has_role(conn, c, Role.ADMIN)
         if is_admin:
             query = "SELECT * FROM vilkikai ORDER BY tech_apziura ASC"


### PR DESCRIPTION
## Summary
- centralize Add button/title with `title_with_add`
- use the helper across management modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686281e0f6288324b11322673f7b1a0c