### PR TITLE
Add theme switcher and config

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,2 @@
+[theme]
+base="light"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ This repository contains a Streamlit based application for logistics companies. 
    ```
    The main page displays a horizontal menu for modules such as shipments, trucks, trailers, groups, drivers, clients, employees, planning and updates.
 
+4. To enable dark mode, open the sidebar in the running app and choose **Dark** in the Theme selector.
+
 ## Naudojimas
 
 Paleidus programą veikia prisijungimo sistema. Pirmą kartą duomenų bazėje automatiškai sukuriamas naudotojas **admin** su slaptažodžiu **admin**. Prisijungus šiuo vartotoju galima patvirtinti kitų naudotojų registracijas.

--- a/main.py
+++ b/main.py
@@ -5,6 +5,23 @@ from modules.roles import Role
 # 1) Puslapio nustatymai
 st.set_page_config(layout="wide")
 
+# Theme selection stored in session_state
+if "theme" not in st.session_state:
+    st.session_state.theme = "Light"
+
+st.config.set_option("theme.base", st.session_state.theme.lower())
+
+selected = st.sidebar.selectbox(
+    "Theme",
+    ["Light", "Dark"],
+    index=0 if st.session_state.theme == "Light" else 1,
+)
+
+if selected != st.session_state.theme:
+    st.session_state.theme = selected
+    st.config.set_option("theme.base", selected.lower())
+    st.experimental_rerun()
+
 # 2) Minimalus CSS – meniu prigludęs prie viršaus
 st.markdown(
     """


### PR DESCRIPTION
## Summary
- add `.streamlit/config.toml` with default light theme
- add sidebar selectbox to switch theme in `main.py`
- document dark mode usage in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686285de6cfc8324b29f65e1f4c7716e