### PR TITLE
Fix theme switch error

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 # main.py
 import streamlit as st
 from modules.roles import Role
+from modules.utils import rerun
 
 # 1) Puslapio nustatymai
 st.set_page_config(layout="wide")
@@ -20,7 +21,7 @@ selected = st.sidebar.selectbox(
 if selected != st.session_state.theme:
     st.session_state.theme = selected
     st.config.set_option("theme.base", selected.lower())
-    st.experimental_rerun()
+    rerun()
 
 # 2) Minimalus CSS – meniu prigludęs prie viršaus
 st.markdown(


### PR DESCRIPTION
## Summary
- import `rerun` helper
- use `rerun()` instead of deprecated `st.experimental_rerun()`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686287b0544483248b2811056a143769