### PR TITLE
Unify table display with edit buttons

### DIFF
--- a/modules/audit.py
+++ b/modules/audit.py
@@ -2,6 +2,7 @@ import json
 import pandas as pd
 import streamlit as st
 from datetime import datetime
+from .utils import display_table_with_edit
 
 
 def log_action(conn, c, user_id, action, table_name, record_id=None, details=None):
@@ -46,4 +47,4 @@ def show(conn, c):
             return str(val)
 
     df["details"] = df["details"].apply(parse_details)
-    st.dataframe(df)
+    display_table_with_edit(df, None)

--- a/modules/darbuotojai.py
+++ b/modules/darbuotojai.py
@@ -3,7 +3,7 @@ import pandas as pd
 from . import login
 from .roles import Role
 from .audit import log_action
-from .utils import rerun, title_with_add
+from .utils import rerun, title_with_add, display_table_with_edit
 
 def show(conn, c):
     # Užtikrinti, kad egzistuotų stulpelis „aktyvus“ darbuotojų lentelėje
@@ -89,20 +89,11 @@ def show(conn, c):
             if val:
                 df_filt = df_filt[df_filt[col].astype(str).str.contains(val, case=False, na=False)]
 
-        # 1.3) Eilučių atvaizdavimas su redagavimo mygtuku (be headerių po filtrų)
-        for _, row in df_filt.iterrows():
-            row_cols = st.columns(len(df_filt.columns) + 1)
-            for i, col in enumerate(df_filt.columns):
-                if col == "aktyvus":
-                    row_cols[i].write("Taip" if row[col] == 1 else "Ne")
-                else:
-                    row_cols[i].write(row[col])
-            row_cols[-1].button(
-                "✏️",
-                key=f"edit_emp_{row['id']}",
-                on_click=start_edit,
-                args=(row['id'],)
-            )
+        df_show = df_filt.copy()
+        if "aktyvus" in df_show.columns:
+            df_show["aktyvus"] = df_show["aktyvus"].apply(lambda v: "Taip" if v == 1 else "Ne")
+
+        display_table_with_edit(df_show, start_edit, id_col="id")
         return
 
     # 2. DETALĖS / NAUJAS DARBUOTOJAS

--- a/modules/klientai.py
+++ b/modules/klientai.py
@@ -3,7 +3,7 @@ import pandas as pd
 from . import login
 from .roles import Role
 from .constants import EU_COUNTRIES, country_flag
-from .utils import rerun, title_with_add
+from .utils import rerun, title_with_add, display_table_with_edit
 
 def show(conn, c):
     # 1. Užtikrinti, kad egzistuotų reikiami stulpeliai
@@ -110,17 +110,8 @@ def show(conn, c):
             if val:
                 df_filt = df_filt[df_filt[col].astype(str).str.contains(val, case=False, na=False)]
 
-        # Duomenų eilutės su redagavimo mygtuku (be antraštės)
-        for _, row in df_filt.iterrows():
-            row_cols = st.columns(len(df_filt.columns) + 1)
-            for i, col in enumerate(df_filt.columns):
-                row_cols[i].write(row[col])
-            row_cols[-1].button(
-                "✏️",
-                key=f"edit_{row['id']}",
-                on_click=start_edit,
-                args=(row['id'],)
-            )
+        df_show = df_filt.copy()
+        display_table_with_edit(df_show, start_edit, id_col="id")
         return
 
     # 5. Detali forma / naujas įrašas

--- a/modules/kroviniai.py
+++ b/modules/kroviniai.py
@@ -4,7 +4,7 @@ from datetime import date, time, timedelta
 from . import login
 from .roles import Role
 from .constants import EU_COUNTRIES, country_flag
-from .utils import rerun, title_with_add
+from .utils import rerun, title_with_add, display_table_with_edit
 
 HEADER_LABELS = {
     "id": "ID",
@@ -251,22 +251,9 @@ def show(conn, c):
                 if v:
                     df_f = df_f[df_f[col].astype(str).str.contains(v, case=False, na=False)]
 
-            hdr = st.columns(len(df_disp.columns) + 1)
-            for i, col in enumerate(df_disp.columns):
-                label = HEADER_LABELS.get(col, col.replace("_", "<br>")[:14])
-                hdr[i].markdown(f"<b>{label}</b>", unsafe_allow_html=True)
-            hdr[-1].markdown("<b>Veiksmai</b>", unsafe_allow_html=True)
-
-            for _, row in df_f.iterrows():
-                row_cols = st.columns(len(df_disp.columns) + 1)
-                for i, col in enumerate(df_disp.columns):
-                    row_cols[i].write(row[col])
-                row_cols[-1].button(
-                    "✏️",
-                    key=f"edit_{row['id']}",
-                    on_click=edit_cargo,
-                    args=(row['id'],)
-                )
+            header_map = {col: HEADER_LABELS.get(col, col.replace("_", " ")) for col in df_disp.columns}
+            df_show = df_f.rename(columns=header_map)
+            display_table_with_edit(df_show, edit_cargo, id_col="id")
 
             st.download_button(
                 "💾 Eksportuoti kaip CSV",

--- a/modules/priekabos.py
+++ b/modules/priekabos.py
@@ -2,7 +2,7 @@ import streamlit as st
 import pandas as pd
 from datetime import date
 from .audit import log_action
-from .utils import rerun, title_with_add
+from .utils import rerun, title_with_add, display_table_with_edit
 
 def show(conn, c):
 
@@ -266,17 +266,8 @@ def show(conn, c):
                 df_filt[col].astype(str).str.lower().str.startswith(val.lower())
             ]
 
-    # 7.5) Lentelės eilutės su redagavimo mygtuku (be headerių po filtrų)
-    for _, row in df_filt.iterrows():
-        row_cols = st.columns(len(df_filt.columns) + 1)
-        for i, col in enumerate(df_filt.columns):
-            row_cols[i].write(row[col])
-        row_cols[-1].button(
-            "✏️",
-            key=f"edit_{row['id']}",
-            on_click=edit,
-            args=(row['id'],)
-        )
+        df_show = df_filt.copy()
+        display_table_with_edit(df_show, edit, id_col="id")
 
     # 7.6) Eksportas į CSV
     csv = df.to_csv(index=False, sep=';').encode('utf-8')

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -15,3 +15,61 @@ def title_with_add(title: str, button_label: str, on_click=None):
     left, right = st.columns([9, 1])
     left.title(title)
     return right.button(button_label, on_click=on_click, use_container_width=True)
+
+def display_table_with_edit(df, edit_callback=None, id_col="id"):
+    """Display a dataframe with a column of edit buttons.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Data to display.
+    edit_callback : callable or None
+        Function to call with the row identifier when an edit button is clicked.
+        If None, the dataframe is displayed without edit buttons.
+    id_col : str
+        Name of the column containing the unique row identifier.
+    """
+    if df is None or df.empty:
+        st.dataframe(df)
+        return
+
+    if id_col not in df.columns:
+        id_col = df.columns[0]
+
+    df_disp = df.reset_index(drop=True).copy()
+
+    if edit_callback is None:
+        st.dataframe(df_disp, hide_index=True)
+        return
+
+    try:
+        df_disp["✏️"] = ""
+
+        def _on_click(row):
+            rid = df_disp.loc[row, id_col]
+            edit_callback(rid)
+
+        st.data_editor(
+            df_disp,
+            hide_index=True,
+            disabled=True,
+            column_config={
+                "✏️": st.column_config.ButtonColumn(
+                    label="✏️",
+                    on_click=_on_click,
+                )
+            },
+            use_container_width=True,
+        )
+    except Exception:
+        for _, row in df_disp.iterrows():
+            cols = st.columns(len(df_disp.columns) + 1)
+            for i, col in enumerate(df_disp.columns[:-1]):
+                cols[i].write(row[col])
+            cols[-1].button(
+                "✏️",
+                key=f"edit_{row[id_col]}",
+                on_click=edit_callback,
+                args=(row[id_col],),
+            )
+

--- a/modules/vairuotojai.py
+++ b/modules/vairuotojai.py
@@ -4,7 +4,7 @@ import pandas as pd
 from datetime import date
 from . import login
 from .roles import Role
-from .utils import rerun, title_with_add
+from .utils import rerun, title_with_add, display_table_with_edit
 
 # ---------- Konstantos ----------
 TAUTYBES = [
@@ -293,9 +293,6 @@ def show(conn, c):
         }
     )
 
-    # ---------- Lentelės atvaizdavimas ----------
-    for _, row in df_disp.iterrows():
-        cols = st.columns(len(df_disp.columns) + 1)
-        for i, col in enumerate(df_disp.columns):
-            cols[i].write(row[col])
-        cols[-1].button("✏️", key=f"edit_{row['id']}", on_click=_edit_vair, args=(row["id"],))
+    df_disp = df_disp
+    display_table_with_edit(df_disp, _edit_vair, id_col="id")
+

--- a/modules/vilkikai.py
+++ b/modules/vilkikai.py
@@ -3,7 +3,7 @@ import pandas as pd
 from datetime import date
 from . import login
 from .roles import Role
-from .utils import rerun, title_with_add
+from .utils import rerun, title_with_add, display_table_with_edit
 
 def show(conn, c):
     # 1) Užtikriname, kad lentelėje „vilkikai“ būtų visi reikalingi stulpeliai
@@ -209,17 +209,8 @@ def show(conn, c):
                     df_filt[col].astype(str).str.lower().str.startswith(val.lower())
                 ]
 
-        # 6.5) Sąrašas su redagavimo mygtukais
-        for _, row in df_filt.iterrows():
-            row_cols = st.columns(len(df_filt.columns) + 1)
-            for i, col in enumerate(df_filt.columns):
-                row_cols[i].write(row[col])
-            row_cols[-1].button(
-                "✏️",
-                key=f"edit_{row['numeris']}",
-                on_click=edit_vilk,
-                args=(row['numeris'],)
-            )
+        df_show = df_filt.copy()
+        display_table_with_edit(df_show, edit_vilk, id_col="numeris")
 
         # 6.6) Eksportas į CSV
         csv = df.to_csv(index=False, sep=';').encode('utf-8')


### PR DESCRIPTION
## Summary
- add `display_table_with_edit` helper
- use new function across entity modules
- show audit log with same table style

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686299e432008324b6c7b03e94542b8b