### PR TITLE
Implement trailer type admin

### DIFF
--- a/main.py
+++ b/main.py
@@ -50,6 +50,7 @@ from modules import (
     audit,
     planavimas,
     update,
+    trailer_types,
     login,
 )
 
@@ -72,11 +73,13 @@ module_functions = {
     "Audit": audit.show,
     "Planavimas": planavimas.show,
     "Update": update.show,
+    "Priekabų tipai": trailer_types.show,
 }
 
 MODULE_ROLES = {
     "Registracijos": [Role.ADMIN, Role.COMPANY_ADMIN],
     "Audit": [Role.ADMIN],
+    "Priekabų tipai": [Role.ADMIN],
 }
 
 def allowed(name: str) -> bool:

--- a/modules/priekabos.py
+++ b/modules/priekabos.py
@@ -53,6 +53,12 @@ def show(conn, c):
             (st.session_state.get('imone'),)
         ).fetchall()
     ]
+    priekabu_tipai_list = [
+        r[0]
+        for r in c.execute(
+            "SELECT reiksme FROM lookup WHERE kategorija = 'Priekabos tipas' ORDER BY reiksme"
+        ).fetchall()
+    ]
 
     # 3) Sesijos būsena
     if 'selected_priek' not in st.session_state:
@@ -93,8 +99,8 @@ def show(conn, c):
 
         row = df_sel.iloc[0]
         with st.form("edit_form", clear_on_submit=False):
-            # 5.1) Priekabos tipas – DROPlistas su fiksuotomis reikšmėmis
-            priekabu_tipas_opts = ["", "Standartinis Tentas", "Kietašonė puspriekabė", "Šaldytuvas"]
+            # 5.1) Priekabos tipas – reikšmės iš DB
+            priekabu_tipas_opts = [""] + priekabu_tipai_list
             tip_idx = 0
             if row['priekabu_tipas'] in priekabu_tipas_opts:
                 tip_idx = priekabu_tipas_opts.index(row['priekabu_tipas'])
@@ -157,7 +163,7 @@ def show(conn, c):
     # 6) Naujos priekabos įvedimo forma
     if sel == 0:
         with st.form("new_form", clear_on_submit=True):
-            priekabu_tipas_opts = ["", "Standartinis Tentas", "Kietašonė puspriekabė", "Šaldytuvas"]
+            priekabu_tipas_opts = [""] + priekabu_tipai_list
             tip = st.selectbox("Priekabos tipas", priekabu_tipas_opts)
 
             num = st.text_input("Numeris")

--- a/modules/trailer_types.py
+++ b/modules/trailer_types.py
@@ -1,0 +1,103 @@
+import streamlit as st
+from . import login
+from .roles import Role
+from .utils import title_with_add
+
+CATEGORY = "Priekabos tipas"
+
+
+def show(conn, c):
+    """Admin interface to manage trailer types."""
+    if not login.has_role(conn, c, Role.ADMIN):
+        st.error("Neturite teisių")
+        return
+
+    # Ensure lookup table exists
+    c.execute(
+        """
+        CREATE TABLE IF NOT EXISTS lookup (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            kategorija TEXT,
+            reiksme TEXT UNIQUE
+        )
+        """
+    )
+    conn.commit()
+
+    if "show_add_type" not in st.session_state:
+        st.session_state.show_add_type = False
+    if "edit_type" not in st.session_state:
+        st.session_state.edit_type = None
+
+    if title_with_add("Priekabų tipai", "➕ Pridėti tipą"):
+        st.session_state.show_add_type = True
+
+    # ----- Edit existing type -----
+    if st.session_state.edit_type:
+        rec_id, initial = st.session_state.edit_type
+        with st.form("edit_type_form"):
+            val = st.text_input("Priekabos tipas", value=initial)
+            save = st.form_submit_button("💾 Išsaugoti")
+            cancel = st.form_submit_button("🔙 Atšaukti")
+        if cancel:
+            st.session_state.edit_type = None
+        if save:
+            if val.strip():
+                try:
+                    c.execute("UPDATE lookup SET reiksme=? WHERE id=?", (val.strip(), rec_id))
+                    conn.commit()
+                    st.session_state.edit_type = None
+                    st.success("✅ Išsaugota")
+                    st.experimental_rerun()
+                except Exception as e:
+                    st.error(f"❌ Klaida: {e}")
+            else:
+                st.warning("⚠️ Įveskite tipą.")
+        return
+
+    # ----- Add new type form -----
+    if st.session_state.show_add_type:
+        with st.form("add_type_form", clear_on_submit=True):
+            val = st.text_input("Priekabos tipas")
+            save = st.form_submit_button("💾 Išsaugoti")
+            cancel = st.form_submit_button("🔙 Atšaukti")
+        if cancel:
+            st.session_state.show_add_type = False
+        elif save:
+            if val.strip():
+                try:
+                    c.execute(
+                        "INSERT INTO lookup (kategorija, reiksme) VALUES (?, ?)",
+                        (CATEGORY, val.strip()),
+                    )
+                    conn.commit()
+                    st.session_state.show_add_type = False
+                    st.success("✅ Įrašyta")
+                    st.experimental_rerun()
+                except Exception as e:
+                    st.error(f"❌ Klaida: {e}")
+            else:
+                st.warning("⚠️ Įveskite tipą.")
+        return
+
+    st.markdown("---")
+    st.subheader("Priekabų tipų sąrašas")
+    rows = c.execute(
+        "SELECT id, reiksme FROM lookup WHERE kategorija=? ORDER BY reiksme",
+        (CATEGORY,),
+    ).fetchall()
+    if not rows:
+        st.info("Nėra priekabų tipų.")
+        return
+
+    for rec_id, val in rows:
+        cols = st.columns([8, 1, 1])
+        cols[0].write(val)
+        if cols[1].button("✏️", key=f"edit_{rec_id}"):
+            st.session_state.edit_type = (rec_id, val)
+            st.experimental_rerun()
+        if cols[2].button("🗑️", key=f"del_{rec_id}"):
+            c.execute("DELETE FROM lookup WHERE id=?", (rec_id,))
+            conn.commit()
+            st.success("❎ Ištrinta")
+            st.experimental_rerun()

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -1,0 +1,18 @@
+from db import init_db
+
+
+def test_lookup_table_and_insert(tmp_path):
+    db_file = tmp_path / "l.db"
+    conn, c = init_db(str(db_file))
+    c.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='lookup'")
+    assert c.fetchone() is not None
+    c.execute(
+        "INSERT INTO lookup (kategorija, reiksme) VALUES (?, ?)",
+        ("Priekabos tipas", "TestTipas"),
+    )
+    conn.commit()
+    c.execute(
+        "SELECT reiksme FROM lookup WHERE kategorija=? AND reiksme=?",
+        ("Priekabos tipas", "TestTipas"),
+    )
+    assert c.fetchone() is not None


### PR DESCRIPTION
## Summary
- add trailer type management module
- get trailer types from DB in trailer view
- register admin page for trailer types
- test lookup table helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_6862b0d7eed08324bca1f71b4a04fc04