### PR TITLE
Add settings module with trailer defaults

### DIFF
--- a/main.py
+++ b/main.py
@@ -51,6 +51,7 @@ from modules import (
     planavimas,
     update,
     trailer_types,
+    settings,
     login,
 )
 
@@ -74,12 +75,14 @@ module_functions = {
     "Planavimas": planavimas.show,
     "Update": update.show,
     "Priekabų tipai": trailer_types.show,
+    "Nustatymai": settings.show,
 }
 
 MODULE_ROLES = {
     "Registracijos": [Role.ADMIN, Role.COMPANY_ADMIN],
     "Audit": [Role.ADMIN],
     "Priekabų tipai": [Role.ADMIN],
+    "Nustatymai": [Role.ADMIN],
 }
 
 def allowed(name: str) -> bool:

--- a/modules/settings.py
+++ b/modules/settings.py
@@ -1,0 +1,70 @@
+import streamlit as st
+from . import trailer_types, login
+from .roles import Role
+
+DEFAULT_CATEGORY = "Numatytas priekabos tipas"
+
+
+def get_default_trailer_type(c, imone: str) -> str | None:
+    c.execute(
+        "SELECT reiksme FROM company_settings WHERE imone=? AND kategorija=?",
+        (imone, DEFAULT_CATEGORY),
+    )
+    row = c.fetchone()
+    return row[0] if row else None
+
+
+def set_default_trailer_type(conn, c, imone: str, value: str | None) -> None:
+    c.execute(
+        "DELETE FROM company_settings WHERE imone=? AND kategorija=?",
+        (imone, DEFAULT_CATEGORY),
+    )
+    if value:
+        c.execute(
+            "INSERT INTO company_settings (imone, kategorija, reiksme) VALUES (?,?,?)",
+            (imone, DEFAULT_CATEGORY, value),
+        )
+    conn.commit()
+
+
+def show(conn, c):
+    """Settings page embedding trailer type management."""
+    is_admin = login.has_role(conn, c, Role.ADMIN)
+    is_comp_admin = login.has_role(conn, c, Role.COMPANY_ADMIN)
+    if not (is_admin or is_comp_admin):
+        st.error("Neturite teisių")
+        return
+
+    st.header("Nustatymai")
+
+    trailer_types.show(conn, c)
+
+    imone = st.session_state.get("imone")
+    if not imone:
+        return
+
+    st.markdown("---")
+    st.subheader("Numatytasis priekabos tipas")
+
+    rows = c.execute(
+        "SELECT reiksme FROM company_settings WHERE imone=? AND kategorija='Priekabos tipas' ORDER BY reiksme",
+        (imone,),
+    ).fetchall()
+    if rows:
+        options = [r[0] for r in rows]
+    else:
+        options = [
+            r[0]
+            for r in c.execute(
+                "SELECT reiksme FROM lookup WHERE kategorija='Priekabos tipas' ORDER BY reiksme"
+            ).fetchall()
+        ]
+
+    current = get_default_trailer_type(c, imone)
+    idx = options.index(current) + 1 if current in options else 0
+    choice = st.selectbox("Pasirinkite numatytąjį priekabos tipą", [""] + options, index=idx)
+
+    if st.button("💾 Išsaugoti nustatymą"):
+        set_default_trailer_type(conn, c, imone, choice or None)
+        st.success("✅ Išsaugota")
+

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,23 @@
+from db import init_db
+from modules import settings
+
+
+def test_default_trailer_type_read_write(tmp_path):
+    db_file = tmp_path / "s.db"
+    conn, c = init_db(str(db_file))
+
+    imone = "ACME"
+    # ensure reading when none returns None
+    assert settings.get_default_trailer_type(c, imone) is None
+
+    settings.set_default_trailer_type(conn, c, imone, "Tent")
+    assert settings.get_default_trailer_type(c, imone) == "Tent"
+
+    # update value
+    settings.set_default_trailer_type(conn, c, imone, "Kieta")
+    assert settings.get_default_trailer_type(c, imone) == "Kieta"
+
+    # clear value
+    settings.set_default_trailer_type(conn, c, imone, None)
+    assert settings.get_default_trailer_type(c, imone) is None
+


### PR DESCRIPTION
## Summary
- add new `modules/settings.py` for managing trailer type defaults
- include new module in `main.py` sidebar/menu
- test reading and updating default trailer type setting

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6862b9215dd08324a581985e6df65a95