### PR TITLE
Fix duplicate Streamlit widgets

### DIFF
--- a/modules/settings.py
+++ b/modules/settings.py
@@ -37,7 +37,8 @@ def show(conn, c):
 
     st.header("Nustatymai")
 
-    trailer_types.show(conn, c)
+    # Embed trailer type management with unique widget keys
+    trailer_types.show(conn, c, key_prefix="settings_")
 
     imone = st.session_state.get("imone")
     if not imone:

--- a/modules/trailer_types.py
+++ b/modules/trailer_types.py
@@ -6,7 +6,7 @@ from .utils import title_with_add, rerun
 CATEGORY = "Priekabos tipas"
 
 
-def show(conn, c):
+def show(conn, c, *, key_prefix: str = ""):
     """Interface to manage trailer types."""
     is_admin = login.has_role(conn, c, Role.ADMIN)
     is_comp_admin = login.has_role(conn, c, Role.COMPANY_ADMIN)
@@ -43,13 +43,13 @@ def show(conn, c):
     if "edit_type" not in st.session_state:
         st.session_state.edit_type = None
 
-    if title_with_add("Priekabų tipai", "➕ Pridėti tipą"):
+    if title_with_add("Priekabų tipai", "➕ Pridėti tipą", key=f"{key_prefix}add_btn"):
         st.session_state.show_add_type = True
 
     # ----- Edit existing type -----
     if st.session_state.edit_type:
         rec_id, initial = st.session_state.edit_type
-        with st.form("edit_type_form"):
+        with st.form(f"{key_prefix}edit_type_form"):
             val = st.text_input("Priekabos tipas", value=initial)
             save = st.form_submit_button("💾 Išsaugoti")
             cancel = st.form_submit_button("🔙 Atšaukti")
@@ -72,7 +72,7 @@ def show(conn, c):
 
     # ----- Add new type form -----
     if st.session_state.show_add_type:
-        with st.form("add_type_form", clear_on_submit=True):
+        with st.form(f"{key_prefix}add_type_form", clear_on_submit=True):
             val = st.text_input("Priekabos tipas")
             save = st.form_submit_button("💾 Išsaugoti")
             cancel = st.form_submit_button("🔙 Atšaukti")
@@ -120,10 +120,10 @@ def show(conn, c):
     for rec_id, val in rows:
         cols = st.columns([8, 1, 1])
         cols[0].write(val)
-        if cols[1].button("✏️", key=f"edit_{rec_id}"):
+        if cols[1].button("✏️", key=f"{key_prefix}edit_{rec_id}"):
             st.session_state.edit_type = (rec_id, val)
             rerun()
-        if cols[2].button("🗑️", key=f"del_{rec_id}"):
+        if cols[2].button("🗑️", key=f"{key_prefix}del_{rec_id}"):
             table = "lookup" if is_admin else "company_settings"
             c.execute(f"DELETE FROM {table} WHERE id=?", (rec_id,))
             conn.commit()

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -10,8 +10,26 @@ def rerun() -> None:
         st.experimental_rerun()
 
 
-def title_with_add(title: str, button_label: str, on_click=None):
-    """Display a page title with an aligned "add" button."""
+def title_with_add(title: str, button_label: str, on_click=None, *, key: str | None = None):
+    """Display a page title with an aligned "add" button.
+
+    Parameters
+    ----------
+    title:
+        The title text to display.
+    button_label:
+        The label for the action button.
+    on_click:
+        Optional callback to run when the button is clicked.
+    key:
+        Optional Streamlit widget key to allow multiple instances on the same page.
+    """
+
     left, right = st.columns([9, 1])
     left.title(title)
-    return right.button(button_label, on_click=on_click, use_container_width=True)
+    return right.button(
+        button_label,
+        on_click=on_click,
+        use_container_width=True,
+        key=key,
+    )


### PR DESCRIPTION
## Summary
- allow specifying key in `title_with_add`
- prefix widget keys for trailer types module
- embed trailer types settings with unique keys

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6862babdda6c8324b00577a0a020f363