### PR TITLE
Fix key conflicts in trailer types UI

### DIFF
--- a/modules/trailer_types.py
+++ b/modules/trailer_types.py
@@ -6,7 +6,7 @@ from .utils import title_with_add, rerun
 CATEGORY = "Priekabos tipas"
 
 
-def show(conn, c, *, key_prefix: str = ""):
+def show(conn, c, *, key_prefix: str = "trailer_types_"):
     """Interface to manage trailer types."""
     is_admin = login.has_role(conn, c, Role.ADMIN)
     is_comp_admin = login.has_role(conn, c, Role.COMPANY_ADMIN)


### PR DESCRIPTION
## Summary
- prevent widget key collisions by giving the trailer types page a default key prefix

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6862bc551e448324b2436a141afae405