### PR TITLE
Fix login form and adjust menu

### DIFF
--- a/main.py
+++ b/main.py
@@ -50,7 +50,6 @@ from modules import (
     audit,
     planavimas,
     update,
-    trailer_types,
     settings,
     login,
 )
@@ -74,14 +73,12 @@ module_functions = {
     "Audit": audit.show,
     "Planavimas": planavimas.show,
     "Update": update.show,
-    "Priekabų tipai": trailer_types.show,
     "Nustatymai": settings.show,
 }
 
 MODULE_ROLES = {
     "Registracijos": [Role.ADMIN, Role.COMPANY_ADMIN],
     "Audit": [Role.ADMIN],
-    "Priekabų tipai": [Role.ADMIN],
     "Nustatymai": [Role.ADMIN],
 }
 

--- a/modules/login.py
+++ b/modules/login.py
@@ -86,9 +86,13 @@ def show(conn, c):
             st.sidebar.success(msg)
 
         st.sidebar.subheader("Prisijungimas")
-        username = st.sidebar.text_input("El. paštas")
-        password = st.sidebar.text_input("Slaptažodis", type="password")
-        if st.sidebar.button("Prisijungti"):
+        with st.sidebar.form("login_form"):
+            username = st.text_input("El. paštas")
+            password = st.text_input("Slaptažodis", type="password")
+            login_submit = st.form_submit_button("Prisijungti")
+            register_submit = st.form_submit_button("Registruotis")
+
+        if login_submit:
             user_id, imone = verify_user(conn, c, username, password)
             if user_id:
                 st.session_state.user_id = user_id
@@ -97,7 +101,8 @@ def show(conn, c):
                 rerun()
             else:
                 st.sidebar.error("Neteisingi prisijungimo duomenys")
-        if st.sidebar.button("Registruotis"):
+
+        if register_submit:
             st.session_state.show_register = True
             rerun()
 


### PR DESCRIPTION
## Summary
- allow pressing Enter to submit the login form
- remove `Priekabų tipai` from the main menu since it lives in Settings

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6862be158ae08324bc9ce60f5cea31b6