### PR TITLE
Add default trailer types and specs module

### DIFF
--- a/db.py
+++ b/db.py
@@ -56,6 +56,41 @@ def init_db(db_path: str | None = None):
 
         conn.commit()
 
+    # Default trailer types
+    trailer_types = [
+        "Van",
+        "Tautliner",
+        "Box",
+        "Open",
+        "Trax Walking Floor",
+        "Coil",
+        "Jumbo Trailer",
+        "Mega Trailer",
+        "Isothermic",
+        "Refrigerated",
+        "Freezer",
+        "Multi Temperature",
+        "Flat",
+        "Lowloader",
+        "Public Works Tiper",
+        "Cereal Tippers",
+        "Steel Through",
+        "Armoured Through",
+        "Palletable Bulk Carrier",
+        "Walking Floor",
+        "Liquid Tank",
+        "Pulverulent Tank",
+        "Container 20 feet",
+        "Container 40 feet",
+        "Container 45 feet",
+    ]
+    for t in trailer_types:
+        c.execute(
+            "INSERT OR IGNORE INTO lookup (kategorija, reiksme) VALUES (?, ?)",
+            ("Priekabos tipas", t),
+        )
+    conn.commit()
+
     # Per-įmonės nustatymų lentelė
     c.execute(
         """
@@ -142,6 +177,21 @@ def init_db(db_path: str | None = None):
     cols = [row[1] for row in c.fetchall()]
     if 'imone' not in cols:
         c.execute("ALTER TABLE priekabos ADD COLUMN imone TEXT")
+    conn.commit()
+
+    c.execute(
+        """
+        CREATE TABLE IF NOT EXISTS trailer_specs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tipas TEXT UNIQUE,
+            ilgis REAL,
+            plotis REAL,
+            aukstis REAL,
+            keliamoji_galia REAL,
+            talpa REAL
+        )
+        """
+    )
     conn.commit()
 
     c.execute("""

--- a/main.py
+++ b/main.py
@@ -42,6 +42,7 @@ from modules import (
     kroviniai,
     vilkikai,
     priekabos,
+    trailer_specs,
     grupes,
     vairuotojai,
     klientai,
@@ -65,6 +66,7 @@ module_functions = {
     "Užsakymai": kroviniai.show,
     "Vilkikai": vilkikai.show,
     "Priekabos": priekabos.show,
+    "Priekabų specifikacijos": trailer_specs.show,
     "Grupės": grupes.show,
     "Vairuotojai": vairuotojai.show,
     "Klientai": klientai.show,
@@ -79,6 +81,7 @@ module_functions = {
 MODULE_ROLES = {
     "Registracijos": [Role.ADMIN, Role.COMPANY_ADMIN],
     "Audit": [Role.ADMIN],
+    "Priekabų specifikacijos": [Role.ADMIN],
     "Nustatymai": [Role.ADMIN],
 }
 

--- a/modules/trailer_specs.py
+++ b/modules/trailer_specs.py
@@ -1,0 +1,115 @@
+import streamlit as st
+from . import login
+from .roles import Role
+from .utils import title_with_add, rerun
+
+
+def show(conn, c):
+    """Manage trailer specification records."""
+    if not login.has_role(conn, c, Role.ADMIN):
+        st.error("Neturite teisių")
+        return
+
+    c.execute(
+        """
+        CREATE TABLE IF NOT EXISTS trailer_specs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tipas TEXT UNIQUE,
+            ilgis REAL,
+            plotis REAL,
+            aukstis REAL,
+            keliamoji_galia REAL,
+            talpa REAL
+        )
+        """
+    )
+    conn.commit()
+
+    if "spec_add" not in st.session_state:
+        st.session_state.spec_add = False
+    if "spec_edit" not in st.session_state:
+        st.session_state.spec_edit = None
+
+    if title_with_add("Priekabų charakteristikos", "➕ Pridėti", key="add_spec_btn"):
+        st.session_state.spec_add = True
+
+    if st.session_state.spec_edit:
+        rec_id = st.session_state.spec_edit
+        row = c.execute(
+            "SELECT tipas, ilgis, plotis, aukstis, keliamoji_galia, talpa FROM trailer_specs WHERE id=?",
+            (rec_id,),
+        ).fetchone()
+        if not row:
+            st.session_state.spec_edit = None
+        else:
+            with st.form("edit_spec_form"):
+                tipas = st.text_input("Tipas", value=row[0])
+                ilgis = st.number_input("Ilgis", value=row[1] or 0.0)
+                plotis = st.number_input("Plotis", value=row[2] or 0.0)
+                aukstis = st.number_input("Aukštis", value=row[3] or 0.0)
+                galia = st.number_input("Keliamoji galia", value=row[4] or 0.0)
+                talpa = st.number_input("Talpa", value=row[5] or 0.0)
+                save = st.form_submit_button("💾 Išsaugoti")
+                cancel = st.form_submit_button("🔙 Atšaukti")
+            if cancel:
+                st.session_state.spec_edit = None
+            if save:
+                c.execute(
+                    """
+                    UPDATE trailer_specs
+                    SET tipas=?, ilgis=?, plotis=?, aukstis=?, keliamoji_galia=?, talpa=?
+                    WHERE id=?
+                    """,
+                    (tipas.strip(), ilgis, plotis, aukstis, galia, talpa, rec_id),
+                )
+                conn.commit()
+                st.session_state.spec_edit = None
+                st.success("✅ Išsaugota")
+                rerun()
+        return
+
+    if st.session_state.spec_add:
+        with st.form("add_spec_form", clear_on_submit=True):
+            tipas = st.text_input("Tipas")
+            ilgis = st.number_input("Ilgis", value=0.0)
+            plotis = st.number_input("Plotis", value=0.0)
+            aukstis = st.number_input("Aukštis", value=0.0)
+            galia = st.number_input("Keliamoji galia", value=0.0)
+            talpa = st.number_input("Talpa", value=0.0)
+            save = st.form_submit_button("💾 Išsaugoti")
+            cancel = st.form_submit_button("🔙 Atšaukti")
+        if cancel:
+            st.session_state.spec_add = False
+        elif save:
+            if tipas.strip():
+                c.execute(
+                    "INSERT INTO trailer_specs (tipas, ilgis, plotis, aukstis, keliamoji_galia, talpa) VALUES (?,?,?,?,?,?)",
+                    (tipas.strip(), ilgis, plotis, aukstis, galia, talpa),
+                )
+                conn.commit()
+                st.session_state.spec_add = False
+                st.success("✅ Įrašyta")
+                rerun()
+            else:
+                st.warning("⚠️ Įveskite tipą.")
+        return
+
+    st.subheader("Specifikacijų sąrašas")
+    rows = c.execute(
+        "SELECT id, tipas, ilgis, plotis, aukstis, keliamoji_galia, talpa FROM trailer_specs ORDER BY tipas"
+    ).fetchall()
+    if not rows:
+        st.info("Nėra įrašų.")
+        return
+    for spec in rows:
+        spec_id, tipas, ilgis, plotis, aukstis, galia, talpa = spec
+        cols = st.columns([4,2,2,2,2,2,1])
+        cols[0].write(tipas)
+        cols[1].write(ilgis or "")
+        cols[2].write(plotis or "")
+        cols[3].write(aukstis or "")
+        cols[4].write(galia or "")
+        cols[5].write(talpa or "")
+        if cols[6].button("✏️", key=f"edit_spec_{spec_id}"):
+            st.session_state.spec_edit = spec_id
+            rerun()

--- a/tests/test_default_trailer_types.py
+++ b/tests/test_default_trailer_types.py
@@ -1,0 +1,11 @@
+from db import init_db
+
+
+def test_default_trailer_types_inserted(tmp_path):
+    db_file = tmp_path / "dtr.db"
+    conn, c = init_db(str(db_file))
+    rows = [r[0] for r in c.execute(
+        "SELECT reiksme FROM lookup WHERE kategorija='Priekabos tipas'"
+    ).fetchall()]
+    assert "Tautliner" in rows
+    assert "Box" in rows


### PR DESCRIPTION
## Summary
- insert a predefined list of trailer types in `init_db`
- create new `trailer_specs` table
- expose a Streamlit module to manage trailer specs
- wire the module into the main menu for admins
- test that default types exist after DB initialization

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6862cc5219808324a97c61f08ae90be8