### PR TITLE
Add ordered default trailer types

### DIFF
--- a/modules/priekabos.py
+++ b/modules/priekabos.py
@@ -3,7 +3,7 @@ import pandas as pd
 from datetime import date
 from .audit import log_action
 from .utils import rerun, title_with_add
-from .settings import get_default_trailer_type
+from .settings import get_default_trailer_types
 
 def show(conn, c):
 
@@ -108,9 +108,11 @@ def show(conn, c):
         row = df_sel.iloc[0]
         with st.form("edit_form", clear_on_submit=False):
             # 5.1) Priekabos tipas – reikšmės iš DB
-            priekabu_tipas_opts = [""] + priekabu_tipai_list
+            defaults = get_default_trailer_types(c, st.session_state.get('imone'))
+            ordered = defaults + [t for t in priekabu_tipai_list if t not in defaults]
+            priekabu_tipas_opts = [""] + ordered
             tip_idx = 0
-            default_tip = get_default_trailer_type(c, st.session_state.get('imone'))
+            default_tip = defaults[0] if defaults else None
             current_tip = row['priekabu_tipas'] or default_tip
             if current_tip in priekabu_tipas_opts:
                 tip_idx = priekabu_tipas_opts.index(current_tip)
@@ -173,8 +175,10 @@ def show(conn, c):
     # 6) Naujos priekabos įvedimo forma
     if sel == 0:
         with st.form("new_form", clear_on_submit=True):
-            priekabu_tipas_opts = [""] + priekabu_tipai_list
-            default_tip = get_default_trailer_type(c, st.session_state.get('imone'))
+            defaults = get_default_trailer_types(c, st.session_state.get('imone'))
+            ordered = defaults + [t for t in priekabu_tipai_list if t not in defaults]
+            priekabu_tipas_opts = [""] + ordered
+            default_tip = defaults[0] if defaults else None
             idx = priekabu_tipas_opts.index(default_tip) if default_tip in priekabu_tipas_opts else 0
             tip = st.selectbox("Priekabos tipas", priekabu_tipas_opts, index=idx)
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2,22 +2,29 @@ from db import init_db
 from modules import settings
 
 
-def test_default_trailer_type_read_write(tmp_path):
+def test_default_trailer_types_read_write(tmp_path):
     db_file = tmp_path / "s.db"
     conn, c = init_db(str(db_file))
 
     imone = "ACME"
-    # ensure reading when none returns None
-    assert settings.get_default_trailer_type(c, imone) is None
+    assert settings.get_default_trailer_types(c, imone) == []
 
-    settings.set_default_trailer_type(conn, c, imone, "Tent")
-    assert settings.get_default_trailer_type(c, imone) == "Tent"
+    settings.set_default_trailer_types(conn, c, imone, ["Tent", "Box"])
+    assert settings.get_default_trailer_types(c, imone) == ["Tent", "Box"]
 
-    # update value
-    settings.set_default_trailer_type(conn, c, imone, "Kieta")
-    assert settings.get_default_trailer_type(c, imone) == "Kieta"
+    settings.set_default_trailer_types(conn, c, imone, ["Mega"])
+    assert settings.get_default_trailer_types(c, imone) == ["Mega"]
 
-    # clear value
-    settings.set_default_trailer_type(conn, c, imone, None)
-    assert settings.get_default_trailer_type(c, imone) is None
+    settings.set_default_trailer_types(conn, c, imone, [])
+    assert settings.get_default_trailer_types(c, imone) == []
+
+
+def test_default_trailer_types_order(tmp_path):
+    db_file = tmp_path / "o.db"
+    conn, c = init_db(str(db_file))
+
+    imone = "B"
+    vals = ["Box", "Tent", "Mega"]
+    settings.set_default_trailer_types(conn, c, imone, vals)
+    assert settings.get_default_trailer_types(c, imone) == vals
 


### PR DESCRIPTION
## Summary
- create `company_default_trailers` table and migrate old defaults
- manage multiple ordered defaults in `modules.settings`
- read ordered defaults when choosing trailer type
- update tests for new behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi', 'bcrypt')*

------
https://chatgpt.com/codex/tasks/task_e_6862e6dd1b44832492f93f4270aca75a