### PR TITLE
Add FastAPI web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository contains a Streamlit based application for logistics companies. The app manages shipments, vehicles and staff information in a single dashboard and stores all data in a local SQLite database.
 
+Besides the Streamlit UI, the repository now provides an alternative FastAPI based web interface located in the `web_app` directory. This interface relies on DataTables for an Excel-style look and can be started locally without Streamlit.
+
 ## Setup
 
 1. Create and activate a Python virtual environment and install the

--- a/web_app/main.py
+++ b/web_app/main.py
@@ -1,0 +1,90 @@
+from fastapi import FastAPI, Request, Form, HTTPException
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+import sqlite3
+from db import init_db
+
+app = FastAPI()
+
+app.mount('/static', StaticFiles(directory='web_app/static'), name='static')
+templates = Jinja2Templates(directory='web_app/templates')
+
+# Initialize DB and ensure tables exist
+conn, cursor = init_db()
+
+# Ensure shipments table has required columns
+EXPECTED_KROVINIAI_COLUMNS = {
+    'klientas': 'TEXT',
+    'uzsakymo_numeris': 'TEXT',
+    'pakrovimo_data': 'TEXT',
+    'iskrovimo_data': 'TEXT',
+    'kilometrai': 'INTEGER',
+    'frachtas': 'REAL',
+    'busena': 'TEXT',
+    'imone': 'TEXT'
+}
+cursor.execute('PRAGMA table_info(kroviniai)')
+existing = {r[1] for r in cursor.fetchall()}
+for col, typ in EXPECTED_KROVINIAI_COLUMNS.items():
+    if col not in existing:
+        cursor.execute(f'ALTER TABLE kroviniai ADD COLUMN {col} {typ}')
+conn.commit()
+
+@app.get('/', response_class=HTMLResponse)
+def index(request: Request):
+    return templates.TemplateResponse('index.html', {'request': request})
+
+@app.get('/kroviniai', response_class=HTMLResponse)
+def kroviniai_list(request: Request):
+    return templates.TemplateResponse('kroviniai_list.html', {'request': request})
+
+@app.get('/kroviniai/add', response_class=HTMLResponse)
+def kroviniai_add_form(request: Request):
+    return templates.TemplateResponse('kroviniai_form.html', {'request': request, 'data': {}})
+
+@app.get('/kroviniai/{cid}/edit', response_class=HTMLResponse)
+def kroviniai_edit_form(cid: int, request: Request):
+    row = cursor.execute('SELECT * FROM kroviniai WHERE id=?', (cid,)).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail='Not found')
+    columns = [col[1] for col in cursor.execute('PRAGMA table_info(kroviniai)')]
+    data = dict(zip(columns, row))
+    return templates.TemplateResponse('kroviniai_form.html', {'request': request, 'data': data})
+
+@app.post('/kroviniai/save')
+def kroviniai_save(
+    request: Request,
+    cid: int = Form(0),
+    klientas: str = Form(...),
+    uzsakymo_numeris: str = Form(...),
+    pakrovimo_data: str = Form(...),
+    iskrovimo_data: str = Form(...),
+    kilometrai: int = Form(0),
+    frachtas: float = Form(0.0),
+    busena: str = Form('Nesuplanuotas'),
+    imone: str = Form(''),
+):
+    if cid:
+        cursor.execute(
+            'UPDATE kroviniai SET klientas=?, uzsakymo_numeris=?, pakrovimo_data=?, iskrovimo_data=?, kilometrai=?, frachtas=?, busena=?, imone=? WHERE id=?',
+            (klientas, uzsakymo_numeris, pakrovimo_data, iskrovimo_data, kilometrai, frachtas, busena, imone, cid)
+        )
+    else:
+        cursor.execute(
+            'INSERT INTO kroviniai (klientas, uzsakymo_numeris, pakrovimo_data, iskrovimo_data, kilometrai, frachtas, busena, imone) VALUES (?,?,?,?,?,?,?,?)',
+            (klientas, uzsakymo_numeris, pakrovimo_data, iskrovimo_data, kilometrai, frachtas, busena, imone)
+        )
+        cid = cursor.lastrowid
+    conn.commit()
+    return RedirectResponse(f'/kroviniai', status_code=303)
+
+@app.get('/api/kroviniai')
+def kroviniai_api():
+    cursor.execute('SELECT * FROM kroviniai')
+    rows = cursor.fetchall()
+    columns = [col[1] for col in cursor.execute('PRAGMA table_info(kroviniai)')]
+    data = [dict(zip(columns, row)) for row in rows]
+    return {'data': data}
+

--- a/web_app/templates/base.html
+++ b/web_app/templates/base.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Logistics App</title>
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css">
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+</head>
+<body>
+    <nav>
+        <a href="/">Pradžia</a> |
+        <a href="/kroviniai">Kroviniai</a>
+    </nav>
+    <hr>
+    {% block content %}{% endblock %}
+</body>
+</html>

--- a/web_app/templates/index.html
+++ b/web_app/templates/index.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Sveiki atvykę</h2>
+<p>Papildoma sąsaja be Streamlit.</p>
+{% endblock %}

--- a/web_app/templates/kroviniai_form.html
+++ b/web_app/templates/kroviniai_form.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>{% if data.id %}Redaguoti krovinį{% else %}Naujas krovinys{% endif %}</h2>
+<form method="post" action="/kroviniai/save">
+    <input type="hidden" name="cid" value="{{ data.id or 0 }}">
+    <label>Klientas: <input type="text" name="klientas" value="{{ data.klientas or '' }}"></label><br>
+    <label>Užsakymo nr.: <input type="text" name="uzsakymo_numeris" value="{{ data.uzsakymo_numeris or '' }}"></label><br>
+    <label>Pakrovimo data: <input type="date" name="pakrovimo_data" value="{{ data.pakrovimo_data or '' }}"></label><br>
+    <label>Iškrovimo data: <input type="date" name="iskrovimo_data" value="{{ data.iskrovimo_data or '' }}"></label><br>
+    <label>Kilometrai: <input type="number" name="kilometrai" value="{{ data.kilometrai or 0 }}"></label><br>
+    <label>Frachtas: <input type="number" step="0.01" name="frachtas" value="{{ data.frachtas or 0 }}"></label><br>
+    <label>Būsena: <input type="text" name="busena" value="{{ data.busena or 'Nesuplanuotas' }}"></label><br>
+    <label>Įmonė: <input type="text" name="imone" value="{{ data.imone or '' }}"></label><br>
+    <button type="submit">Išsaugoti</button>
+</form>
+{% endblock %}

--- a/web_app/templates/kroviniai_list.html
+++ b/web_app/templates/kroviniai_list.html
@@ -1,0 +1,40 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Kroviniai</h2>
+<a href="/kroviniai/add">Pridėti naują</a>
+<table id="cargo-table" class="display" style="width:100%">
+    <thead>
+        <tr>
+            <th>ID</th>
+            <th>Klientas</th>
+            <th>Užsakymo nr.</th>
+            <th>Pakrovimo data</th>
+            <th>Iškrovimo data</th>
+            <th>Kilometrai</th>
+            <th>Frachtas</th>
+            <th>Būsena</th>
+            <th>Veiksmai</th>
+        </tr>
+    </thead>
+</table>
+<script>
+$(document).ready(function() {
+    $('#cargo-table').DataTable({
+        ajax: '/api/kroviniai',
+        columns: [
+            { data: 'id' },
+            { data: 'klientas' },
+            { data: 'uzsakymo_numeris' },
+            { data: 'pakrovimo_data' },
+            { data: 'iskrovimo_data' },
+            { data: 'kilometrai' },
+            { data: 'frachtas' },
+            { data: 'busena' },
+            { data: null, render: function (data, type, row) {
+                return '<a href="/kroviniai/' + row.id + '/edit">Edit</a>';
+            }}
+        ]
+    });
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a simple FastAPI based UI under `web_app`
- render tables with DataTables and include edit forms
- update README with instructions about the new UI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68638c8009948324930b9aee4a7e4bc1