### PR TITLE
Add FastAPI docs and basic tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,13 @@ Besides the Streamlit UI, the repository now provides an alternative FastAPI bas
    ```
    The main page displays a horizontal menu for modules such as shipments, trucks, trailers, groups, drivers, clients, employees, planning and updates.
 
-4. To enable dark mode, open the sidebar in the running app and choose **Dark** in the Theme selector.
+4. Alternatively you can run the FastAPI interface located in `web_app`:
+   ```bash
+   uvicorn web_app.main:app --reload
+   ```
+   This starts a local server on http://127.0.0.1:8000 without Streamlit.
+
+5. To enable dark mode in the Streamlit UI, open the sidebar in the running app and choose **Dark** in the Theme selector.
 
 ## Naudojimas
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 streamlit
 pandas
 bcrypt
+fastapi
+uvicorn
+jinja2
+python-multipart

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -1,0 +1,38 @@
+import importlib
+import os
+from fastapi.testclient import TestClient
+
+
+def create_client(tmp_path):
+    os.environ['DB_PATH'] = str(tmp_path / 'app.db')
+    module = importlib.import_module('web_app.main')
+    importlib.reload(module)
+    return TestClient(module.app)
+
+
+def test_kroviniai_empty(tmp_path):
+    client = create_client(tmp_path)
+    resp = client.get('/api/kroviniai')
+    assert resp.status_code == 200
+    assert resp.json() == {'data': []}
+
+
+def test_save_and_fetch(tmp_path):
+    client = create_client(tmp_path)
+    form = {
+        'cid': '0',
+        'klientas': 'ACME',
+        'uzsakymo_numeris': '123',
+        'pakrovimo_data': '2023-01-01',
+        'iskrovimo_data': '2023-01-02',
+        'kilometrai': '10',
+        'frachtas': '20',
+        'busena': 'Nesuplanuotas',
+        'imone': 'A',
+    }
+    resp = client.post('/kroviniai/save', data=form, allow_redirects=False)
+    assert resp.status_code == 303
+    resp = client.get('/api/kroviniai')
+    data = resp.json()['data']
+    assert len(data) == 1
+    assert data[0]['klientas'] == 'ACME'


### PR DESCRIPTION
## Summary
- document how to start the FastAPI web interface
- include FastAPI packages in root requirements
- provide a static directory for the new web app
- refactor FastAPI app to use per-request DB connections
- add unit tests for the FastAPI endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6863980b03348324922e098137e862bb