### PR TITLE
Add Windows startup script

### DIFF
--- a/start_work2_server.bat
+++ b/start_work2_server.bat
@@ -1,0 +1,10 @@
+@echo off
+cd /d %~dp0
+
+if not exist venv (
+    python -m venv venv
+    call venv\Scripts\python.exe -m pip install -r requirements.txt
+)
+
+call venv\Scripts\python.exe -m uvicorn web_app.main:app --reload
+pause


### PR DESCRIPTION
## Summary
- add a `start_work2_server.bat` helper for Windows

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6863b0d78be88324bf1aaa6329be9faf