### PR TITLE
Add trucks section to FastAPI web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains a Streamlit based application for logistics companies. The app manages shipments, vehicles and staff information in a single dashboard and stores all data in a local SQLite database.
 
-Besides the Streamlit UI, the repository now provides an alternative FastAPI based web interface located in the `web_app` directory. This interface relies on DataTables for an Excel-style look and can be started locally without Streamlit.
+Besides the Streamlit UI, the repository now provides an alternative FastAPI based web interface located in the `web_app` directory. This interface relies on DataTables for an Excel-style look and can be started locally without Streamlit. Initially it only supported shipment management but now also includes a simple trucks section.
 
 ## Setup
 

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -4,35 +4,59 @@ from fastapi.testclient import TestClient
 
 
 def create_client(tmp_path):
-    os.environ['DB_PATH'] = str(tmp_path / 'app.db')
-    module = importlib.import_module('web_app.main')
+    os.environ["DB_PATH"] = str(tmp_path / "app.db")
+    module = importlib.import_module("web_app.main")
     importlib.reload(module)
     return TestClient(module.app)
 
 
 def test_kroviniai_empty(tmp_path):
     client = create_client(tmp_path)
-    resp = client.get('/api/kroviniai')
+    resp = client.get("/api/kroviniai")
     assert resp.status_code == 200
-    assert resp.json() == {'data': []}
+    assert resp.json() == {"data": []}
 
 
 def test_save_and_fetch(tmp_path):
     client = create_client(tmp_path)
     form = {
-        'cid': '0',
-        'klientas': 'ACME',
-        'uzsakymo_numeris': '123',
-        'pakrovimo_data': '2023-01-01',
-        'iskrovimo_data': '2023-01-02',
-        'kilometrai': '10',
-        'frachtas': '20',
-        'busena': 'Nesuplanuotas',
-        'imone': 'A',
+        "cid": "0",
+        "klientas": "ACME",
+        "uzsakymo_numeris": "123",
+        "pakrovimo_data": "2023-01-01",
+        "iskrovimo_data": "2023-01-02",
+        "kilometrai": "10",
+        "frachtas": "20",
+        "busena": "Nesuplanuotas",
+        "imone": "A",
     }
-    resp = client.post('/kroviniai/save', data=form, allow_redirects=False)
+    resp = client.post("/kroviniai/save", data=form, allow_redirects=False)
     assert resp.status_code == 303
-    resp = client.get('/api/kroviniai')
-    data = resp.json()['data']
+    resp = client.get("/api/kroviniai")
+    data = resp.json()["data"]
     assert len(data) == 1
-    assert data[0]['klientas'] == 'ACME'
+    assert data[0]["klientas"] == "ACME"
+
+
+def test_vilkikai_basic(tmp_path):
+    client = create_client(tmp_path)
+    resp = client.get("/api/vilkikai")
+    assert resp.status_code == 200
+    assert resp.json() == {"data": []}
+    form = {
+        "vid": "0",
+        "numeris": "AAA111",
+        "marke": "MAN",
+        "pagaminimo_metai": "2020",
+        "tech_apziura": "2023-01-01",
+        "vadybininkas": "John",
+        "vairuotojai": "A B",
+        "priekaba": "TR1",
+        "imone": "A",
+    }
+    resp = client.post("/vilkikai/save", data=form, allow_redirects=False)
+    assert resp.status_code == 303
+    resp = client.get("/api/vilkikai")
+    data = resp.json()["data"]
+    assert len(data) == 1
+    assert data[0]["numeris"] == "AAA111"

--- a/web_app/main.py
+++ b/web_app/main.py
@@ -9,29 +9,45 @@ from db import init_db
 
 app = FastAPI()
 
-app.mount('/static', StaticFiles(directory='web_app/static'), name='static')
-templates = Jinja2Templates(directory='web_app/templates')
+app.mount("/static", StaticFiles(directory="web_app/static"), name="static")
+templates = Jinja2Templates(directory="web_app/templates")
 
 
 EXPECTED_KROVINIAI_COLUMNS = {
-    'klientas': 'TEXT',
-    'uzsakymo_numeris': 'TEXT',
-    'pakrovimo_data': 'TEXT',
-    'iskrovimo_data': 'TEXT',
-    'kilometrai': 'INTEGER',
-    'frachtas': 'REAL',
-    'busena': 'TEXT',
-    'imone': 'TEXT'
+    "klientas": "TEXT",
+    "uzsakymo_numeris": "TEXT",
+    "pakrovimo_data": "TEXT",
+    "iskrovimo_data": "TEXT",
+    "kilometrai": "INTEGER",
+    "frachtas": "REAL",
+    "busena": "TEXT",
+    "imone": "TEXT",
+}
+
+EXPECTED_VILKIKAI_COLUMNS = {
+    "numeris": "TEXT",
+    "marke": "TEXT",
+    "pagaminimo_metai": "INTEGER",
+    "tech_apziura": "TEXT",
+    "vadybininkas": "TEXT",
+    "vairuotojai": "TEXT",
+    "priekaba": "TEXT",
+    "imone": "TEXT",
 }
 
 
 def ensure_columns(conn: sqlite3.Connection, cursor: sqlite3.Cursor) -> None:
-    """Ensure kroviniai table contains expected columns."""
-    cursor.execute('PRAGMA table_info(kroviniai)')
-    existing = {r[1] for r in cursor.fetchall()}
-    for col, typ in EXPECTED_KROVINIAI_COLUMNS.items():
-        if col not in existing:
-            cursor.execute(f'ALTER TABLE kroviniai ADD COLUMN {col} {typ}')
+    """Ensure required columns exist for tables used by the web app."""
+    tables = {
+        "kroviniai": EXPECTED_KROVINIAI_COLUMNS,
+        "vilkikai": EXPECTED_VILKIKAI_COLUMNS,
+    }
+    for table, cols in tables.items():
+        cursor.execute(f"PRAGMA table_info({table})")
+        existing = {r[1] for r in cursor.fetchall()}
+        for col, typ in cols.items():
+            if col not in existing:
+                cursor.execute(f"ALTER TABLE {table} ADD COLUMN {col} {typ}")
     conn.commit()
 
 
@@ -43,33 +59,42 @@ def get_db() -> Generator[tuple[sqlite3.Connection, sqlite3.Cursor], None, None]
     finally:
         conn.close()
 
-@app.get('/', response_class=HTMLResponse)
+
+@app.get("/", response_class=HTMLResponse)
 def index(request: Request):
-    return templates.TemplateResponse('index.html', {'request': request})
+    return templates.TemplateResponse("index.html", {"request": request})
 
-@app.get('/kroviniai', response_class=HTMLResponse)
+
+@app.get("/kroviniai", response_class=HTMLResponse)
 def kroviniai_list(request: Request):
-    return templates.TemplateResponse('kroviniai_list.html', {'request': request})
+    return templates.TemplateResponse("kroviniai_list.html", {"request": request})
 
-@app.get('/kroviniai/add', response_class=HTMLResponse)
+
+@app.get("/kroviniai/add", response_class=HTMLResponse)
 def kroviniai_add_form(request: Request):
-    return templates.TemplateResponse('kroviniai_form.html', {'request': request, 'data': {}})
+    return templates.TemplateResponse(
+        "kroviniai_form.html", {"request": request, "data": {}}
+    )
 
-@app.get('/kroviniai/{cid}/edit', response_class=HTMLResponse)
+
+@app.get("/kroviniai/{cid}/edit", response_class=HTMLResponse)
 def kroviniai_edit_form(
     cid: int,
     request: Request,
     db: tuple[sqlite3.Connection, sqlite3.Cursor] = Depends(get_db),
 ):
     conn, cursor = db
-    row = cursor.execute('SELECT * FROM kroviniai WHERE id=?', (cid,)).fetchone()
+    row = cursor.execute("SELECT * FROM kroviniai WHERE id=?", (cid,)).fetchone()
     if not row:
-        raise HTTPException(status_code=404, detail='Not found')
-    columns = [col[1] for col in cursor.execute('PRAGMA table_info(kroviniai)')]
+        raise HTTPException(status_code=404, detail="Not found")
+    columns = [col[1] for col in cursor.execute("PRAGMA table_info(kroviniai)")]
     data = dict(zip(columns, row))
-    return templates.TemplateResponse('kroviniai_form.html', {'request': request, 'data': data})
+    return templates.TemplateResponse(
+        "kroviniai_form.html", {"request": request, "data": data}
+    )
 
-@app.post('/kroviniai/save')
+
+@app.post("/kroviniai/save")
 def kroviniai_save(
     request: Request,
     cid: int = Form(0),
@@ -79,31 +104,137 @@ def kroviniai_save(
     iskrovimo_data: str = Form(...),
     kilometrai: int = Form(0),
     frachtas: float = Form(0.0),
-    busena: str = Form('Nesuplanuotas'),
-    imone: str = Form(''),
+    busena: str = Form("Nesuplanuotas"),
+    imone: str = Form(""),
     db: tuple[sqlite3.Connection, sqlite3.Cursor] = Depends(get_db),
 ):
     conn, cursor = db
     if cid:
         cursor.execute(
-            'UPDATE kroviniai SET klientas=?, uzsakymo_numeris=?, pakrovimo_data=?, iskrovimo_data=?, kilometrai=?, frachtas=?, busena=?, imone=? WHERE id=?',
-            (klientas, uzsakymo_numeris, pakrovimo_data, iskrovimo_data, kilometrai, frachtas, busena, imone, cid)
+            "UPDATE kroviniai SET klientas=?, uzsakymo_numeris=?, pakrovimo_data=?, iskrovimo_data=?, kilometrai=?, frachtas=?, busena=?, imone=? WHERE id=?",
+            (
+                klientas,
+                uzsakymo_numeris,
+                pakrovimo_data,
+                iskrovimo_data,
+                kilometrai,
+                frachtas,
+                busena,
+                imone,
+                cid,
+            ),
         )
     else:
         cursor.execute(
-            'INSERT INTO kroviniai (klientas, uzsakymo_numeris, pakrovimo_data, iskrovimo_data, kilometrai, frachtas, busena, imone) VALUES (?,?,?,?,?,?,?,?)',
-            (klientas, uzsakymo_numeris, pakrovimo_data, iskrovimo_data, kilometrai, frachtas, busena, imone)
+            "INSERT INTO kroviniai (klientas, uzsakymo_numeris, pakrovimo_data, iskrovimo_data, kilometrai, frachtas, busena, imone) VALUES (?,?,?,?,?,?,?,?)",
+            (
+                klientas,
+                uzsakymo_numeris,
+                pakrovimo_data,
+                iskrovimo_data,
+                kilometrai,
+                frachtas,
+                busena,
+                imone,
+            ),
         )
         cid = cursor.lastrowid
     conn.commit()
-    return RedirectResponse(f'/kroviniai', status_code=303)
+    return RedirectResponse(f"/kroviniai", status_code=303)
 
-@app.get('/api/kroviniai')
+
+@app.get("/api/kroviniai")
 def kroviniai_api(db: tuple[sqlite3.Connection, sqlite3.Cursor] = Depends(get_db)):
     conn, cursor = db
-    cursor.execute('SELECT * FROM kroviniai')
+    cursor.execute("SELECT * FROM kroviniai")
     rows = cursor.fetchall()
-    columns = [col[1] for col in cursor.execute('PRAGMA table_info(kroviniai)')]
+    columns = [col[1] for col in cursor.execute("PRAGMA table_info(kroviniai)")]
     data = [dict(zip(columns, row)) for row in rows]
-    return {'data': data}
+    return {"data": data}
 
+
+@app.get("/vilkikai", response_class=HTMLResponse)
+def vilkikai_list(request: Request):
+    return templates.TemplateResponse("vilkikai_list.html", {"request": request})
+
+
+@app.get("/vilkikai/add", response_class=HTMLResponse)
+def vilkikai_add_form(request: Request):
+    return templates.TemplateResponse(
+        "vilkikai_form.html", {"request": request, "data": {}}
+    )
+
+
+@app.get("/vilkikai/{vid}/edit", response_class=HTMLResponse)
+def vilkikai_edit_form(
+    vid: int,
+    request: Request,
+    db: tuple[sqlite3.Connection, sqlite3.Cursor] = Depends(get_db),
+):
+    conn, cursor = db
+    row = cursor.execute("SELECT * FROM vilkikai WHERE id=?", (vid,)).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="Not found")
+    columns = [col[1] for col in cursor.execute("PRAGMA table_info(vilkikai)")]
+    data = dict(zip(columns, row))
+    return templates.TemplateResponse(
+        "vilkikai_form.html", {"request": request, "data": data}
+    )
+
+
+@app.post("/vilkikai/save")
+def vilkikai_save(
+    request: Request,
+    vid: int = Form(0),
+    numeris: str = Form(...),
+    marke: str = Form(""),
+    pagaminimo_metai: int = Form(0),
+    tech_apziura: str = Form(""),
+    vadybininkas: str = Form(""),
+    vairuotojai: str = Form(""),
+    priekaba: str = Form(""),
+    imone: str = Form(""),
+    db: tuple[sqlite3.Connection, sqlite3.Cursor] = Depends(get_db),
+):
+    conn, cursor = db
+    if vid:
+        cursor.execute(
+            "UPDATE vilkikai SET numeris=?, marke=?, pagaminimo_metai=?, tech_apziura=?, vadybininkas=?, vairuotojai=?, priekaba=?, imone=? WHERE id=?",
+            (
+                numeris,
+                marke,
+                pagaminimo_metai,
+                tech_apziura,
+                vadybininkas,
+                vairuotojai,
+                priekaba,
+                imone,
+                vid,
+            ),
+        )
+    else:
+        cursor.execute(
+            "INSERT INTO vilkikai (numeris, marke, pagaminimo_metai, tech_apziura, vadybininkas, vairuotojai, priekaba, imone) VALUES (?,?,?,?,?,?,?,?)",
+            (
+                numeris,
+                marke,
+                pagaminimo_metai,
+                tech_apziura,
+                vadybininkas,
+                vairuotojai,
+                priekaba,
+                imone,
+            ),
+        )
+    conn.commit()
+    return RedirectResponse(f"/vilkikai", status_code=303)
+
+
+@app.get("/api/vilkikai")
+def vilkikai_api(db: tuple[sqlite3.Connection, sqlite3.Cursor] = Depends(get_db)):
+    conn, cursor = db
+    cursor.execute("SELECT * FROM vilkikai")
+    rows = cursor.fetchall()
+    columns = [col[1] for col in cursor.execute("PRAGMA table_info(vilkikai)")]
+    data = [dict(zip(columns, row)) for row in rows]
+    return {"data": data}

--- a/web_app/templates/base.html
+++ b/web_app/templates/base.html
@@ -10,7 +10,8 @@
 <body>
     <nav>
         <a href="/">Pradžia</a> |
-        <a href="/kroviniai">Kroviniai</a>
+        <a href="/kroviniai">Kroviniai</a> |
+        <a href="/vilkikai">Vilkikai</a>
     </nav>
     <hr>
     {% block content %}{% endblock %}

--- a/web_app/templates/vilkikai_form.html
+++ b/web_app/templates/vilkikai_form.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>{% if data.id %}Redaguoti vilkiką{% else %}Naujas vilkikas{% endif %}</h2>
+<form method="post" action="/vilkikai/save">
+    <input type="hidden" name="vid" value="{{ data.id or 0 }}">
+    <label>Numeris: <input type="text" name="numeris" value="{{ data.numeris or '' }}"></label><br>
+    <label>Markė: <input type="text" name="marke" value="{{ data.marke or '' }}"></label><br>
+    <label>Pirmos reg. metai: <input type="number" name="pagaminimo_metai" value="{{ data.pagaminimo_metai or 0 }}"></label><br>
+    <label>Tech apžiūra: <input type="date" name="tech_apziura" value="{{ data.tech_apziura or '' }}"></label><br>
+    <label>Vadybininkas: <input type="text" name="vadybininkas" value="{{ data.vadybininkas or '' }}"></label><br>
+    <label>Vairuotojai: <input type="text" name="vairuotojai" value="{{ data.vairuotojai or '' }}"></label><br>
+    <label>Priekaba: <input type="text" name="priekaba" value="{{ data.priekaba or '' }}"></label><br>
+    <label>Įmonė: <input type="text" name="imone" value="{{ data.imone or '' }}"></label><br>
+    <button type="submit">Išsaugoti</button>
+</form>
+{% endblock %}

--- a/web_app/templates/vilkikai_list.html
+++ b/web_app/templates/vilkikai_list.html
@@ -1,0 +1,36 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Vilkikai</h2>
+<a href="/vilkikai/add">Pridėti naują</a>
+<table id="truck-table" class="display" style="width:100%">
+    <thead>
+        <tr>
+            <th>ID</th>
+            <th>Numeris</th>
+            <th>Markė</th>
+            <th>Pirm. registracija</th>
+            <th>Tech apžiūra</th>
+            <th>Vadybininkas</th>
+            <th>Veiksmai</th>
+        </tr>
+    </thead>
+</table>
+<script>
+$(document).ready(function() {
+    $('#truck-table').DataTable({
+        ajax: '/api/vilkikai',
+        columns: [
+            { data: 'id' },
+            { data: 'numeris' },
+            { data: 'marke' },
+            { data: 'pagaminimo_metai' },
+            { data: 'tech_apziura' },
+            { data: 'vadybininkas' },
+            { data: null, render: function (data, type, row) {
+                return '<a href="/vilkikai/' + row.id + '/edit">Edit</a>';
+            }}
+        ]
+    });
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- support management of `vilkikai` (trucks) in the FastAPI `web_app`
- include simple list and form templates for trucks
- expose `/api/vilkikai` endpoint
- update navigation links
- expand tests to cover the new endpoint
- document the extra functionality in README

## Testing
- `black web_app/main.py tests/test_web_app.py`
- `pytest tests/test_web_app.py -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6863b5f515d08324b86fb7ab95d54f9f