### PR TITLE
Add trailer dropdown for truck forms

### DIFF
--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -60,3 +60,24 @@ def test_vilkikai_basic(tmp_path):
     data = resp.json()["data"]
     assert len(data) == 1
     assert data[0]["numeris"] == "AAA111"
+
+
+def test_vilkikai_form_shows_trailers(tmp_path):
+    client = create_client(tmp_path)
+    trailer_form = {
+        "pid": "0",
+        "priekabu_tipas": "Tipas",
+        "numeris": "TR123",
+        "marke": "X",
+        "pagaminimo_metai": "2020",
+        "tech_apziura": "2023-01-01",
+        "draudimas": "2023-01-01",
+        "imone": "A",
+    }
+    resp = client.post("/priekabos/save", data=trailer_form, allow_redirects=False)
+    assert resp.status_code == 303
+
+    resp = client.get("/vilkikai/add")
+    assert resp.status_code == 200
+    assert "<select" in resp.text
+    assert '<option value="TR123"' in resp.text

--- a/web_app/main.py
+++ b/web_app/main.py
@@ -182,9 +182,14 @@ def vilkikai_list(request: Request):
 
 
 @app.get("/vilkikai/add", response_class=HTMLResponse)
-def vilkikai_add_form(request: Request):
+def vilkikai_add_form(
+    request: Request,
+    db: tuple[sqlite3.Connection, sqlite3.Cursor] = Depends(get_db),
+):
+    conn, cursor = db
+    trailers = [r[0] for r in cursor.execute("SELECT numeris FROM priekabos").fetchall()]
     return templates.TemplateResponse(
-        "vilkikai_form.html", {"request": request, "data": {}}
+        "vilkikai_form.html", {"request": request, "data": {}, "trailers": trailers}
     )
 
 
@@ -200,8 +205,9 @@ def vilkikai_edit_form(
         raise HTTPException(status_code=404, detail="Not found")
     columns = [col[1] for col in cursor.execute("PRAGMA table_info(vilkikai)")]
     data = dict(zip(columns, row))
+    trailers = [r[0] for r in cursor.execute("SELECT numeris FROM priekabos").fetchall()]
     return templates.TemplateResponse(
-        "vilkikai_form.html", {"request": request, "data": data}
+        "vilkikai_form.html", {"request": request, "data": data, "trailers": trailers}
     )
 
 

--- a/web_app/templates/vilkikai_form.html
+++ b/web_app/templates/vilkikai_form.html
@@ -9,7 +9,14 @@
     <label>Tech apžiūra: <input type="date" name="tech_apziura" value="{{ data.tech_apziura or '' }}"></label><br>
     <label>Vadybininkas: <input type="text" name="vadybininkas" value="{{ data.vadybininkas or '' }}"></label><br>
     <label>Vairuotojai: <input type="text" name="vairuotojai" value="{{ data.vairuotojai or '' }}"></label><br>
-    <label>Priekaba: <input type="text" name="priekaba" value="{{ data.priekaba or '' }}"></label><br>
+    <label>Priekaba:
+        <select name="priekaba">
+            <option value=""></option>
+            {% for tr in trailers %}
+            <option value="{{ tr }}" {% if data.priekaba == tr %}selected{% endif %}>{{ tr }}</option>
+            {% endfor %}
+        </select>
+    </label><br>
     <label>Įmonė: <input type="text" name="imone" value="{{ data.imone or '' }}"></label><br>
     <button type="submit">Išsaugoti</button>
 </form>


### PR DESCRIPTION
## Summary
- fetch trailer numbers when rendering truck forms
- add a dropdown to select trailers
- include test checking that trailer options show up in the form

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6863f8f979888324a9570ad77e4c75c2