### PR TITLE
Add groups FastAPI module and setup files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.pytest_cache/
+*.db

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ fastapi
 uvicorn
 jinja2
 python-multipart
+httpx

--- a/web_app/templates/base.html
+++ b/web_app/templates/base.html
@@ -13,7 +13,8 @@
         <a href="/kroviniai">Kroviniai</a> |
         <a href="/vilkikai">Vilkikai</a> |
         <a href="/priekabos">Priekabos</a> |
-        <a href="/darbuotojai">Darbuotojai</a>
+        <a href="/darbuotojai">Darbuotojai</a> |
+        <a href="/grupes">Grupės</a>
     </nav>
     <hr>
     {% block content %}{% endblock %}

--- a/web_app/templates/grupes_form.html
+++ b/web_app/templates/grupes_form.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>{% if data.id %}Redaguoti grupę{% else %}Nauja grupė{% endif %}</h2>
+<form method="post" action="/grupes/save">
+    <input type="hidden" name="gid" value="{{ data.id or 0 }}">
+    <label>Numeris: <input type="text" name="numeris" value="{{ data.numeris or '' }}"></label><br>
+    <label>Pavadinimas: <input type="text" name="pavadinimas" value="{{ data.pavadinimas or '' }}"></label><br>
+    <label>Aprašymas: <input type="text" name="aprasymas" value="{{ data.aprasymas or '' }}"></label><br>
+    <label>Įmonė: <input type="text" name="imone" value="{{ data.imone or '' }}"></label><br>
+    <button type="submit">Išsaugoti</button>
+</form>
+{% endblock %}

--- a/web_app/templates/grupes_list.html
+++ b/web_app/templates/grupes_list.html
@@ -1,0 +1,30 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Grupės</h2>
+<a href="/grupes/add">Pridėti naują</a>
+<table id="group-table" class="display" style="width:100%">
+    <thead>
+        <tr>
+            <th>ID</th>
+            <th>Numeris</th>
+            <th>Pavadinimas</th>
+            <th>Veiksmai</th>
+        </tr>
+    </thead>
+</table>
+<script>
+$(document).ready(function() {
+    $('#group-table').DataTable({
+        ajax: '/api/grupes',
+        columns: [
+            { data: 'id' },
+            { data: 'numeris' },
+            { data: 'pavadinimas' },
+            { data: null, render: function (data, type, row) {
+                return '<a href="/grupes/' + row.id + '/edit">Edit</a>';
+            }}
+        ]
+    });
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add project-wide `.gitignore`
- include `httpx` dependency in `requirements.txt`
- extend FastAPI app with groups module
- add groups templates and update navigation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for fastapi/db)*

------
https://chatgpt.com/codex/tasks/task_e_68652b70336883249fe3ea55fdb6a7ef