### PR TITLE
Extend FastAPI with klientai module

### DIFF
--- a/web_app/templates/base.html
+++ b/web_app/templates/base.html
@@ -14,7 +14,8 @@
         <a href="/vilkikai">Vilkikai</a> |
         <a href="/priekabos">Priekabos</a> |
         <a href="/darbuotojai">Darbuotojai</a> |
-        <a href="/grupes">Grupės</a>
+        <a href="/grupes">Grupės</a> |
+        <a href="/klientai">Klientai</a>
     </nav>
     <hr>
     {% block content %}{% endblock %}

--- a/web_app/templates/klientai_form.html
+++ b/web_app/templates/klientai_form.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>{% if data.id %}Redaguoti klientą{% else %}Naujas klientas{% endif %}</h2>
+<form method="post" action="/klientai/save">
+    <input type="hidden" name="cid" value="{{ data.id or 0 }}">
+    <label>Pavadinimas: <input type="text" name="pavadinimas" value="{{ data.pavadinimas or '' }}"></label><br>
+    <label>VAT numeris: <input type="text" name="vat_numeris" value="{{ data.vat_numeris or '' }}"></label><br>
+    <label>Kontaktinis asmuo: <input type="text" name="kontaktinis_asmuo" value="{{ data.kontaktinis_asmuo or '' }}"></label><br>
+    <label>Kontaktinis el. paštas: <input type="email" name="kontaktinis_el_pastas" value="{{ data.kontaktinis_el_pastas or '' }}"></label><br>
+    <label>Kontaktinis tel.: <input type="text" name="kontaktinis_tel" value="{{ data.kontaktinis_tel or '' }}"></label><br>
+    <label>Įmonė: <input type="text" name="imone" value="{{ data.imone or '' }}"></label><br>
+    <button type="submit">Išsaugoti</button>
+</form>
+{% endblock %}

--- a/web_app/templates/klientai_list.html
+++ b/web_app/templates/klientai_list.html
@@ -1,0 +1,32 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Klientai</h2>
+<a href="/klientai/add">Pridėti naują</a>
+<table id="cli-table" class="display" style="width:100%">
+    <thead>
+        <tr>
+            <th>ID</th>
+            <th>Pavadinimas</th>
+            <th>VAT</th>
+            <th>Kontaktinis asmuo</th>
+            <th>Veiksmai</th>
+        </tr>
+    </thead>
+</table>
+<script>
+$(document).ready(function() {
+    $('#cli-table').DataTable({
+        ajax: '/api/klientai',
+        columns: [
+            { data: 'id' },
+            { data: 'pavadinimas' },
+            { data: 'vat_numeris' },
+            { data: 'kontaktinis_asmuo' },
+            { data: null, render: function (data, type, row) {
+                return '<a href="/klientai/' + row.id + '/edit">Edit</a>';
+            }}
+        ]
+    });
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add "Klientai" link to main navigation
- support klientai CRUD pages and API in FastAPI
- ensure klientai columns exist in database

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for fastapi and db)*

------
https://chatgpt.com/codex/tasks/task_e_6865306df18c8324b982343979f1bf4e