### PR TITLE
Expand FastAPI interface with driver management

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains a Streamlit based application for logistics companies. The app manages shipments, vehicles and staff information in a single dashboard and stores all data in a local SQLite database.
 
-Besides the Streamlit UI, the repository now provides an alternative FastAPI based web interface located in the `web_app` directory. This interface relies on DataTables for an Excel-style look and can be started locally without Streamlit. Initially it only supported shipment management but now also includes trucks, trailers, employees, groups, clients and an audit log section.
+Besides the Streamlit UI, the repository now provides an alternative FastAPI based web interface located in the `web_app` directory. This interface relies on DataTables for an Excel-style look and can be started locally without Streamlit. Initially it only supported shipment management but now also includes trucks, trailers, employees, groups, clients, drivers and an audit log section.
 
 ## Setup
 

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -141,3 +141,25 @@ def test_audit_multiple_modules(tmp_path):
     data = resp.json()["data"]
     tables = {row["table_name"] for row in data}
     assert {"kroviniai", "vilkikai"}.issubset(tables)
+
+def test_vairuotojai_basic(tmp_path):
+    client = create_client(tmp_path)
+    resp = client.get("/api/vairuotojai")
+    assert resp.status_code == 200
+    assert resp.json() == {"data": []}
+    form = {
+        "did": "0",
+        "vardas": "Jonas",
+        "pavarde": "Jonaitis",
+        "gimimo_metai": "1980-01-01",
+        "tautybe": "LT",
+        "kadencijos_pabaiga": "",
+        "atostogu_pabaiga": "",
+        "imone": "A",
+    }
+    resp = client.post("/vairuotojai/save", data=form, allow_redirects=False)
+    assert resp.status_code == 303
+    resp = client.get("/api/vairuotojai")
+    data = resp.json()["data"]
+    assert len(data) == 1
+    assert data[0]["vardas"] == "Jonas"

--- a/web_app/templates/base.html
+++ b/web_app/templates/base.html
@@ -12,6 +12,7 @@
         <a href="/">Pradžia</a> |
         <a href="/kroviniai">Kroviniai</a> |
         <a href="/vilkikai">Vilkikai</a> |
+        <a href="/vairuotojai">Vairuotojai</a> |
         <a href="/priekabos">Priekabos</a> |
         <a href="/darbuotojai">Darbuotojai</a> |
         <a href="/grupes">Grupės</a> |

--- a/web_app/templates/vairuotojai_form.html
+++ b/web_app/templates/vairuotojai_form.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>{% if data.id %}Redaguoti vairuotoją{% else %}Naujas vairuotojas{% endif %}</h2>
+<form method="post" action="/vairuotojai/save">
+    <input type="hidden" name="did" value="{{ data.id or 0 }}">
+    <label>Vardas: <input type="text" name="vardas" value="{{ data.vardas or '' }}"></label><br>
+    <label>Pavardė: <input type="text" name="pavarde" value="{{ data.pavarde or '' }}"></label><br>
+    <label>Gimimo data: <input type="date" name="gimimo_metai" value="{{ data.gimimo_metai or '' }}"></label><br>
+    <label>Tautybė: <input type="text" name="tautybe" value="{{ data.tautybe or '' }}"></label><br>
+    <label>Kadencijos pabaiga: <input type="date" name="kadencijos_pabaiga" value="{{ data.kadencijos_pabaiga or '' }}"></label><br>
+    <label>Atostogų pabaiga: <input type="date" name="atostogu_pabaiga" value="{{ data.atostogu_pabaiga or '' }}"></label><br>
+    <label>Įmonė: <input type="text" name="imone" value="{{ data.imone or '' }}"></label><br>
+    <button type="submit">Išsaugoti</button>
+</form>
+{% endblock %}

--- a/web_app/templates/vairuotojai_list.html
+++ b/web_app/templates/vairuotojai_list.html
@@ -1,0 +1,32 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Vairuotojai</h2>
+<a href="/vairuotojai/add">Pridėti naują</a>
+<table id="drv-table" class="display" style="width:100%">
+    <thead>
+        <tr>
+            <th>ID</th>
+            <th>Vardas</th>
+            <th>Pavardė</th>
+            <th>Tautybė</th>
+            <th>Veiksmai</th>
+        </tr>
+    </thead>
+</table>
+<script>
+$(document).ready(function() {
+    $('#drv-table').DataTable({
+        ajax: '/api/vairuotojai',
+        columns: [
+            { data: 'id' },
+            { data: 'vardas' },
+            { data: 'pavarde' },
+            { data: 'tautybe' },
+            { data: null, render: function (data, type, row) {
+                return '<a href="/vairuotojai/' + row.id + '/edit">Edit</a>';
+            }}
+        ]
+    });
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add driver section to FastAPI web app
- link to new page in navigation
- create HTML templates for drivers
- update DB initialization to ensure `vairuotojai` columns
- expose endpoints for listing and editing drivers with audit logging
- test new endpoints
- mention drivers in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68653b774a7c8324a1c62776f54caa37