### PR TITLE
Implement settings page

### DIFF
--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -209,3 +209,17 @@ def test_planavimas_basic(tmp_path):
     assert "columns" in data and "data" in data
     assert any(row[data["columns"][0]].startswith("AAA111") for row in data["data"])
     assert today in data["columns"]
+
+
+def test_settings_defaults(tmp_path):
+    client = create_client(tmp_path)
+    form = {
+        "imone": "A",
+        "values": ["Van", "Box"],
+    }
+    resp = client.post("/settings/save", data=form, allow_redirects=False)
+    assert resp.status_code == 303
+    resp = client.get("/api/default-trailer-types?imone=A")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data == ["Van", "Box"]

--- a/web_app/templates/base.html
+++ b/web_app/templates/base.html
@@ -19,6 +19,7 @@
         <a href="/klientai">Klientai</a> |
         <a href="/planavimas">Planavimas</a> |
         <a href="/trailer-types">Priekabų tipai</a> |
+        <a href="/settings">Nustatymai</a> |
         <a href="/audit">Auditas</a>
     </nav>
     <hr>

--- a/web_app/templates/settings.html
+++ b/web_app/templates/settings.html
@@ -1,0 +1,42 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Numatytieji priekabų tipai</h2>
+<form id="defaults-form" method="post" action="/settings/save">
+    <label>Įmonė: <input type="text" id="imone-field" name="imone" value="A"></label>
+    <div id="rows"></div>
+    <button type="button" id="add-row">Pridėti</button>
+    <button type="submit">Išsaugoti</button>
+</form>
+<script>
+async function loadData() {
+    const typesResp = await fetch('/api/trailer-types');
+    const typesData = await typesResp.json();
+    const opts = typesData.data.map(t => `<option value="${t.reiksme}">${t.reiksme}</option>`).join('');
+    const imone = document.getElementById('imone-field').value;
+    const defResp = await fetch('/api/default-trailer-types?imone=' + encodeURIComponent(imone));
+    const defData = await defResp.json();
+    const container = document.getElementById('rows');
+    function addRow(value='') {
+        const row = document.createElement('div');
+        row.innerHTML = `<select name="values" class="val">${opts}</select>
+            <button type="button" class="up">⬆️</button>
+            <button type="button" class="down">⬇️</button>
+            <button type="button" class="del">🗑️</button>`;
+        container.appendChild(row);
+        if(value) row.querySelector('select').value = value;
+    }
+    defData.data.forEach(v => addRow(v));
+    document.getElementById('add-row').onclick = () => addRow(typesData.data[0]?.reiksme || '');
+    container.addEventListener('click', e => {
+        if(e.target.classList.contains('del')) e.target.parentElement.remove();
+        if(e.target.classList.contains('up')) {
+            const r = e.target.parentElement, p = r.previousElementSibling; if(p) r.parentElement.insertBefore(r, p);
+        }
+        if(e.target.classList.contains('down')) {
+            const r = e.target.parentElement, n = r.nextElementSibling; if(n) r.parentElement.insertBefore(n, r);
+        }
+    });
+}
+loadData();
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- migrate settings module to FastAPI
- add `/settings` route with page to manage default trailer types
- expose API for default trailer types
- update navigation with link to the new page
- test saving and reading defaults

## Testing
- `pytest -q` *(fails: ModuleNotFoundError - fastapi, streamlit)*

------
https://chatgpt.com/codex/tasks/task_e_6865430ff298832485bcdcbead579989