### PR TITLE
Add trailer specs FastAPI module

### DIFF
--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -255,3 +255,26 @@ def test_login_and_register(tmp_path):
         allow_redirects=False,
     )
     assert resp.status_code == 303
+
+
+def test_trailer_specs_basic(tmp_path):
+    client = create_client(tmp_path)
+    resp = client.get("/api/trailer-specs")
+    assert resp.status_code == 200
+    assert resp.json() == {"data": []}
+
+    form = {
+        "sid": "0",
+        "tipas": "Mega",
+        "ilgis": "13.6",
+        "plotis": "2.5",
+        "aukstis": "3",
+        "keliamoji_galia": "24000",
+        "talpa": "90",
+    }
+    resp = client.post("/trailer-specs/save", data=form, allow_redirects=False)
+    assert resp.status_code == 303
+    resp = client.get("/api/trailer-specs")
+    data = resp.json()["data"]
+    assert len(data) == 1
+    assert data[0]["tipas"] == "Mega"

--- a/web_app/templates/base.html
+++ b/web_app/templates/base.html
@@ -19,6 +19,7 @@
         <a href="/klientai">Klientai</a> |
         <a href="/planavimas">Planavimas</a> |
         <a href="/trailer-types">Priekabų tipai</a> |
+        <a href="/trailer-specs">Priekabų spec.</a> |
         <a href="/settings">Nustatymai</a> |
         <a href="/audit">Auditas</a>
         {% if request.session.get('user_id') %}

--- a/web_app/templates/trailer_specs_form.html
+++ b/web_app/templates/trailer_specs_form.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>{% if data.id %}Redaguoti specifikaciją{% else %}Nauja specifikacija{% endif %}</h2>
+<form method="post" action="/trailer-specs/save">
+    <input type="hidden" name="sid" value="{{ data.id or 0 }}">
+    <label>Tipas: <input type="text" name="tipas" value="{{ data.tipas or '' }}"></label><br>
+    <label>Ilgis: <input type="number" step="any" name="ilgis" value="{{ data.ilgis or '' }}"></label><br>
+    <label>Plotis: <input type="number" step="any" name="plotis" value="{{ data.plotis or '' }}"></label><br>
+    <label>Aukštis: <input type="number" step="any" name="aukstis" value="{{ data.aukstis or '' }}"></label><br>
+    <label>Keliamoji galia: <input type="number" step="any" name="keliamoji_galia" value="{{ data.keliamoji_galia or '' }}"></label><br>
+    <label>Talpa: <input type="number" step="any" name="talpa" value="{{ data.talpa or '' }}"></label><br>
+    <button type="submit">Išsaugoti</button>
+</form>
+{% endblock %}

--- a/web_app/templates/trailer_specs_list.html
+++ b/web_app/templates/trailer_specs_list.html
@@ -1,0 +1,38 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Priekabų specifikacijos</h2>
+<a href="/trailer-specs/add">Pridėti naują</a>
+<table id="ts-table" class="display" style="width:100%">
+    <thead>
+        <tr>
+            <th>ID</th>
+            <th>Tipas</th>
+            <th>Ilgis</th>
+            <th>Plotis</th>
+            <th>Aukštis</th>
+            <th>Keliamoji galia</th>
+            <th>Talpa</th>
+            <th>Veiksmai</th>
+        </tr>
+    </thead>
+</table>
+<script>
+$(document).ready(function() {
+    $('#ts-table').DataTable({
+        ajax: '/api/trailer-specs',
+        columns: [
+            { data: 'id' },
+            { data: 'tipas' },
+            { data: 'ilgis' },
+            { data: 'plotis' },
+            { data: 'aukstis' },
+            { data: 'keliamoji_galia' },
+            { data: 'talpa' },
+            { data: null, render: function (data, type, row) {
+                return '<a href="/trailer-specs/' + row.id + '/edit">Edit</a>';
+            }}
+        ]
+    });
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `trailer_specs` table columns to FastAPI
- expose new `/trailer-specs` CRUD routes
- show menu link to the specs module
- templates for listing/editing trailer specs
- test FastAPI trailer specs endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686549c71b4483248b3b0e39005ffafc