### PR TITLE
Continue FastAPI migration with registration approvals

### DIFF
--- a/web_app/templates/base.html
+++ b/web_app/templates/base.html
@@ -21,6 +21,7 @@
         <a href="/trailer-types">Priekabų tipai</a> |
         <a href="/trailer-specs">Priekabų spec.</a> |
         <a href="/settings">Nustatymai</a> |
+        <a href="/registracijos">Registracijos</a> |
         <a href="/audit">Auditas</a>
         {% if request.session.get('user_id') %}
             | Prisijungęs: {{ request.session.get('username') }} (<a href="/logout">Atsijungti</a>)

--- a/web_app/templates/registracijos_list.html
+++ b/web_app/templates/registracijos_list.html
@@ -1,0 +1,57 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Laukiantys naudotojai</h2>
+<table id="reg-table" class="display" style="width:100%">
+    <thead>
+        <tr>
+            <th>ID</th>
+            <th>Vartotojas</th>
+            <th>Įmonė</th>
+            <th>Vardas</th>
+            <th>Pavardė</th>
+            <th>Pareigybė</th>
+            <th>Veiksmai</th>
+        </tr>
+    </thead>
+</table>
+<h2>Aktyvūs naudotojai</h2>
+<table id="active-table" class="display" style="width:100%">
+    <thead>
+        <tr>
+            <th>Vartotojas</th>
+            <th>Įmonė</th>
+            <th>Paskutinis prisijungimas</th>
+        </tr>
+    </thead>
+</table>
+<script>
+$(document).ready(function() {
+    $('#reg-table').DataTable({
+        ajax: '/api/registracijos',
+        order: [[0, 'asc']],
+        columns: [
+            { data: 'id' },
+            { data: 'username' },
+            { data: 'imone' },
+            { data: 'vardas' },
+            { data: 'pavarde' },
+            { data: 'pareigybe' },
+            { data: null, render: function(data, type, row) {
+                return '<a href="/registracijos/' + row.id + '/approve">Patvirtinti</a> '
+                     + '<a href="/registracijos/' + row.id + '/approve-admin">Admin</a> '
+                     + '<a href="/registracijos/' + row.id + '/delete">Šalinti</a>';
+            }}
+        ]
+    });
+    $('#active-table').DataTable({
+        ajax: '/api/aktyvus',
+        order: [[0, 'asc']],
+        columns: [
+            { data: 'username' },
+            { data: 'imone' },
+            { data: 'last_login' }
+        ]
+    });
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add registration management endpoints to FastAPI app
- include user approval and deletion logic with audit logging
- expose `/api/registracijos` and `/api/aktyvus`
- create menu entry and template for the new section
- test user approval flow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68654e3c22488324a851a3b5e8f55709