### PR TITLE
Add module entrypoint for FastAPI web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Besides the Streamlit UI, the repository now provides an alternative FastAPI bas
    ```
    This starts a local server on http://127.0.0.1:8000 without Streamlit.
 
+   The web application can also be executed directly as a module:
+   ```bash
+   python -m web_app
+   ```
+   which runs the same server using built-in defaults.
+
 5. To enable dark mode in the Streamlit UI, open the sidebar in the running app and choose **Dark** in the Theme selector.
 
 ## Naudojimas

--- a/start_work2_server.bat
+++ b/start_work2_server.bat
@@ -10,5 +10,5 @@ if not exist venv (
     )
 )
 
-call venv\Scripts\python.exe -m uvicorn web_app.main:app --reload
+call venv\Scripts\python.exe -m web_app
 pause

--- a/start_work2_server.sh
+++ b/start_work2_server.sh
@@ -11,4 +11,4 @@ if [ ! -d venv ]; then
     fi
 fi
 
-./venv/bin/python -m uvicorn web_app.main:app --reload
+./venv/bin/python -m web_app

--- a/web_app/__main__.py
+++ b/web_app/__main__.py
@@ -1,0 +1,6 @@
+from uvicorn import run
+from .main import app
+
+if __name__ == "__main__":
+    run(app, host="127.0.0.1", port=8000, reload=True)
+


### PR DESCRIPTION
## Summary
- make `web_app` runnable via `python -m web_app`
- update start scripts to use the new entrypoint
- document the alternative launch method in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6865622d02648324a958a0e5633718e3