### PR TITLE
Add audit CSV export

### DIFF
--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -107,6 +107,11 @@ def test_audit_log_records_actions(tmp_path):
     assert row["action"] == "insert"
     assert "details" in row
 
+    resp = client.get("/api/audit.csv")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/csv")
+    assert "table_name" in resp.text.splitlines()[0]
+
 
 def test_audit_multiple_modules(tmp_path):
     client = create_client(tmp_path)

--- a/web_app/templates/audit_list.html
+++ b/web_app/templates/audit_list.html
@@ -11,6 +11,7 @@
         <option value="">Visos</option>
     </select>
 </label>
+<button id="download-csv">Atsisiųsti CSV</button>
 <table id="audit-table" class="display" style="width:100%">
     <thead>
         <tr>
@@ -60,6 +61,16 @@ $(document).ready(function() {
 
     $('#user-filter, #table-filter').on('change', function() {
         table.ajax.reload();
+    });
+
+    $('#download-csv').on('click', function() {
+        const params = [];
+        const u = $('#user-filter').val();
+        const t = $('#table-filter').val();
+        if (u) params.push('user=' + encodeURIComponent(u));
+        if (t) params.push('table=' + encodeURIComponent(t));
+        const url = '/api/audit.csv' + (params.length ? '?' + params.join('&') : '');
+        window.location = url;
     });
 });
 </script>


### PR DESCRIPTION
## Summary
- support CSV download of audit logs
- link CSV export button on audit page
- test CSV response

## Testing
- `pytest -q` *(fails: ModuleNotFoundError - fastapi and db modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_68657295a07c83248bafe0e051ff8e1e