### PR TITLE
Add health endpoint for FastAPI web app

### DIFF
--- a/web_app/main.py
+++ b/web_app/main.py
@@ -1510,3 +1510,9 @@ def register_submit(
         "register.html",
         {"request": request, "error": None, "msg": "Parai\u0161ka pateikta"},
     )
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+


### PR DESCRIPTION
## Summary
- add a simple `/health` endpoint that returns JSON status

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686573c94dc883249a6372bcf3a4bf5f