### PR TITLE
Perkelti audit modulo funkcijas į FastAPI

### DIFF
--- a/fastapi_app/app/crud.py
+++ b/fastapi_app/app/crud.py
@@ -46,12 +46,22 @@ def create_audit_log(
     return log
 
 
-def get_audit_logs(db: Session, limit: int = 100) -> list[models.AuditLog]:
+def get_audit_logs(
+    db: Session,
+    limit: int = 100,
+    user_id: UUID | None = None,
+    table_name: str | None = None,
+    action: str | None = None,
+) -> list[models.AuditLog]:
+    query = db.query(models.AuditLog)
+    if user_id:
+        query = query.filter(models.AuditLog.user_id == user_id)
+    if table_name:
+        query = query.filter(models.AuditLog.table_name == table_name)
+    if action:
+        query = query.filter(models.AuditLog.action == action)
     return (
-        db.query(models.AuditLog)
-        .order_by(models.AuditLog.timestamp.desc())
-        .limit(limit)
-        .all()
+        query.order_by(models.AuditLog.timestamp.desc()).limit(limit).all()
     )
 
 

--- a/fastapi_app/tests/test_audit.py
+++ b/fastapi_app/tests/test_audit.py
@@ -69,3 +69,14 @@ def test_create_and_read_audit():
     assert r2.status_code == 200
     data = r2.json()
     assert any(l['action'] == 'test' for l in data)
+
+    # Filtering by user and table name should return the log
+    r3 = client.get(f'/audit?user_id={user.id}&table_name=doc&action=test', headers=headers)
+    assert r3.status_code == 200
+    filtered = r3.json()
+    assert len(filtered) == 1 and filtered[0]['record_id'] == '1'
+
+    # CSV export should contain table header
+    r4 = client.get(f'/audit.csv?user_id={user.id}', headers=headers)
+    assert r4.status_code == 200
+    assert 'table_name' in r4.text.splitlines()[0]


### PR DESCRIPTION
## Summary
- pridėti filtravimą ir CSV eksportą `fastapi_app` auditui
- atnaujinti `/audit` ir naujas `/audit.csv` maršrutas
- papildyti testus auditui

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686584d927b083249287d08cd5e67933