### PR TITLE
Fix session middleware order

### DIFF
--- a/web_app/main.py
+++ b/web_app/main.py
@@ -20,10 +20,6 @@ import pandas as pd
 
 app = FastAPI()
 
-app.add_middleware(
-    SessionMiddleware, secret_key=os.getenv("WEBAPP_SECRET", "devsecret")
-)
-
 
 class AuthMiddleware(BaseHTTPMiddleware):
     """Redirect anonymous users to the login page."""
@@ -41,6 +37,10 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
 
 app.add_middleware(AuthMiddleware)
+
+app.add_middleware(
+    SessionMiddleware, secret_key=os.getenv("WEBAPP_SECRET", "devsecret")
+)
 
 
 def ensure_logged_in(request: Request) -> bool:


### PR DESCRIPTION
## Summary
- ensure SessionMiddleware runs before AuthMiddleware

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686589fd40ac832499248cb405225fa3