### PR TITLE
Fix reload usage for web_app

### DIFF
--- a/web_app/__main__.py
+++ b/web_app/__main__.py
@@ -1,6 +1,9 @@
 from uvicorn import run
-from .main import app
+
+# Import string notation is required for reload to work
+APP_IMPORT = "web_app.main:app"
 
 if __name__ == "__main__":
-    run(app, host="127.0.0.1", port=8000, reload=True)
+    # Pass the application as an import string so `reload` works
+    run(APP_IMPORT, host="127.0.0.1", port=8000, reload=True)
 


### PR DESCRIPTION
## Summary
- fix uvicorn invocation in `web_app/__main__.py` to allow reload

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68658d4ed9d08324bf02634560f5ab9e