### PR TITLE
Align trailer form layout with truck form

### DIFF
--- a/web_app/templates/priekabos_form.html
+++ b/web_app/templates/priekabos_form.html
@@ -3,13 +3,44 @@
 <h2>{% if data.id %}Redaguoti priekabą{% else %}Nauja priekaba{% endif %}</h2>
 <form method="post" action="/priekabos/save">
     <input type="hidden" name="pid" value="{{ data.id or 0 }}">
-    <label>Tipas: <input type="text" name="priekabu_tipas" value="{{ data.priekabu_tipas or '' }}"></label><br>
-    <label>Numeris: <input type="text" name="numeris" value="{{ data.numeris or '' }}"></label><br>
-    <label>Markė: <input type="text" name="marke" value="{{ data.marke or '' }}"></label><br>
-    <label>Pirmos reg. data: <input type="text" name="pagaminimo_metai" value="{{ data.pagaminimo_metai or '' }}"></label><br>
-    <label>Tech apžiūra: <input type="date" name="tech_apziura" value="{{ data.tech_apziura or '' }}"></label><br>
-    <label>Draudimas: <input type="date" name="draudimas" value="{{ data.draudimas or '' }}"></label><br>
-    <label>Įmonė: <input type="text" name="imone" value="{{ data.imone or '' }}"></label><br>
-    <button type="submit">Išsaugoti</button>
+    <div class="form-grid">
+        <label>Tipas
+            <input type="text" name="priekabu_tipas" value="{{ data.priekabu_tipas or '' }}">
+        </label>
+        <label>Numeris
+            <input type="text" name="numeris" value="{{ data.numeris or '' }}">
+        </label>
+        <label>Markė
+            <input type="text" name="marke" value="{{ data.marke or '' }}">
+        </label>
+        <label>Pirmos reg. data
+            <input type="text" name="pagaminimo_metai" value="{{ data.pagaminimo_metai or '' }}">
+        </label>
+        <label>Tech apžiūra
+            <input type="date" name="tech_apziura" value="{{ data.tech_apziura or '' }}">
+        </label>
+        <label>Draudimas
+            <input type="date" name="draudimas" value="{{ data.draudimas or '' }}">
+        </label>
+        <label class="full-width">Įmonė
+            <input type="text" name="imone" value="{{ data.imone or '' }}">
+        </label>
+    </div>
+    <button type="submit">💾 Išsaugoti priekabą</button>
+    <a href="/priekabos">← Grįžti į sąrašą</a>
 </form>
+<style>
+.form-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+}
+.form-grid label {
+    display: flex;
+    flex-direction: column;
+}
+.full-width {
+    grid-column: span 2;
+}
+</style>
 {% endblock %}


### PR DESCRIPTION
## Summary
- rework trailer form layout to use the same grid styling as the truck form

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6865979d5d00832497c0cc842d477f66