### PR TITLE
Add group dropdown and improve form layout

### DIFF
--- a/web_app/templates/grupes_form.html
+++ b/web_app/templates/grupes_form.html
@@ -3,10 +3,35 @@
 <h2>{% if data.id %}Redaguoti grupę{% else %}Nauja grupė{% endif %}</h2>
 <form method="post" action="/grupes/save">
     <input type="hidden" name="gid" value="{{ data.id or 0 }}">
-    <label>Numeris: <input type="text" name="numeris" value="{{ data.numeris or '' }}"></label><br>
-    <label>Pavadinimas: <input type="text" name="pavadinimas" value="{{ data.pavadinimas or '' }}"></label><br>
-    <label>Aprašymas: <input type="text" name="aprasymas" value="{{ data.aprasymas or '' }}"></label><br>
-    <label>Įmonė: <input type="text" name="imone" value="{{ data.imone or '' }}"></label><br>
-    <button type="submit">Išsaugoti</button>
+    <div class="form-grid">
+        <label>Grupės numeris
+            <input type="text" name="numeris" value="{{ data.numeris or '' }}">
+        </label>
+        <label>Pavadinimas
+            <input type="text" name="pavadinimas" value="{{ data.pavadinimas or '' }}">
+        </label>
+        <label class="full-width">Aprašymas
+            <textarea name="aprasymas">{{ data.aprasymas or '' }}</textarea>
+        </label>
+        <label class="full-width">Įmonė
+            <input type="text" name="imone" value="{{ data.imone or '' }}">
+        </label>
+    </div>
+    <button type="submit">💾 Išsaugoti grupę</button>
+    <a href="/grupes">← Atšaukti</a>
 </form>
+<style>
+.form-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+}
+.form-grid label {
+    display: flex;
+    flex-direction: column;
+}
+.full-width {
+    grid-column: span 2;
+}
+</style>
 {% endblock %}

--- a/web_app/templates/grupes_list.html
+++ b/web_app/templates/grupes_list.html
@@ -1,7 +1,9 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2>Grupės</h2>
-<a href="/grupes/add">Pridėti naują</a>
+<div class="page-header">
+    <h2>Grupės</h2>
+    <a class="add-btn" href="/grupes/add">Pridėti grupę</a>
+</div>
 <table id="group-table" class="display" style="width:100%">
     <thead>
         <tr>
@@ -12,6 +14,13 @@
         </tr>
     </thead>
 </table>
+<div class="group-select">
+    <label>Pasirinkite grupę:
+        <select id="grupe-select">
+            <option value="">--</option>
+        </select>
+    </label>
+</div>
 <script>
 $(document).ready(function() {
     $('#group-table').DataTable({
@@ -25,6 +34,25 @@ $(document).ready(function() {
             }}
         ]
     });
+
+    async function loadDropdown() {
+        const resp = await fetch('/api/grupes');
+        const data = await resp.json();
+        const sel = $('#grupe-select');
+        data.data.forEach(g => sel.append(`<option value="${g.id}">${g.numeris}</option>`));
+    }
+    loadDropdown();
 });
 </script>
+<style>
+.page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+}
+.group-select {
+    margin-top: 10px;
+}
+</style>
 {% endblock %}


### PR DESCRIPTION
## Summary
- rework group form layout and include cancel option
- polish groups list view with Add button, dropdown selector, and styling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68659eba59948324bfe975a32fdeb1ed