### PR TITLE
Enhance driver management pages

### DIFF
--- a/web_app/main.py
+++ b/web_app/main.py
@@ -24,6 +24,9 @@ EMPLOYEE_ROLES = [
     "Transporto vadybininkas",
 ]
 
+# Nationality options for driver forms
+DRIVER_NATIONALITIES = ["LT", "BY", "UA", "UZ", "IN", "NG", "PL"]
+
 app = FastAPI()
 
 
@@ -772,7 +775,12 @@ def vairuotojai_list(request: Request):
 @app.get("/vairuotojai/add", response_class=HTMLResponse)
 def vairuotojai_add_form(request: Request):
     return templates.TemplateResponse(
-        "vairuotojai_form.html", {"request": request, "data": {}}
+        "vairuotojai_form.html",
+        {
+            "request": request,
+            "data": {},
+            "tautybes": DRIVER_NATIONALITIES,
+        },
     )
 
 
@@ -789,7 +797,12 @@ def vairuotojai_edit_form(
     columns = [col[1] for col in cursor.execute("PRAGMA table_info(vairuotojai)")]
     data = dict(zip(columns, row))
     return templates.TemplateResponse(
-        "vairuotojai_form.html", {"request": request, "data": data}
+        "vairuotojai_form.html",
+        {
+            "request": request,
+            "data": data,
+            "tautybes": DRIVER_NATIONALITIES,
+        },
     )
 
 

--- a/web_app/templates/vairuotojai_form.html
+++ b/web_app/templates/vairuotojai_form.html
@@ -3,13 +3,42 @@
 <h2>{% if data.id %}Redaguoti vairuotoją{% else %}Naujas vairuotojas{% endif %}</h2>
 <form method="post" action="/vairuotojai/save">
     <input type="hidden" name="did" value="{{ data.id or 0 }}">
-    <label>Vardas: <input type="text" name="vardas" value="{{ data.vardas or '' }}"></label><br>
-    <label>Pavardė: <input type="text" name="pavarde" value="{{ data.pavarde or '' }}"></label><br>
-    <label>Gimimo data: <input type="date" name="gimimo_metai" value="{{ data.gimimo_metai or '' }}"></label><br>
-    <label>Tautybė: <input type="text" name="tautybe" value="{{ data.tautybe or '' }}"></label><br>
-    <label>Kadencijos pabaiga: <input type="date" name="kadencijos_pabaiga" value="{{ data.kadencijos_pabaiga or '' }}"></label><br>
-    <label>Atostogų pabaiga: <input type="date" name="atostogu_pabaiga" value="{{ data.atostogu_pabaiga or '' }}"></label><br>
-    <label>Įmonė: <input type="text" name="imone" value="{{ data.imone or '' }}"></label><br>
-    <button type="submit">Išsaugoti</button>
+    <input type="hidden" name="kadencijos_pabaiga" value="{{ data.kadencijos_pabaiga or '' }}">
+    <input type="hidden" name="imone" value="{{ data.imone or '' }}">
+    <div class="form-grid">
+        <label>Vardas
+            <input type="text" name="vardas" value="{{ data.vardas or '' }}">
+        </label>
+        <label>Pavardė
+            <input type="text" name="pavarde" value="{{ data.pavarde or '' }}">
+        </label>
+        <label>Gimimo data
+            <input type="date" name="gimimo_metai" value="{{ data.gimimo_metai or '' }}">
+        </label>
+        <label>Tautybė
+            <select name="tautybe">
+                <option value=""></option>
+                {% for t in tautybes %}
+                <option value="{{ t }}" {% if t == data.tautybe %}selected{% endif %}>{{ t }}</option>
+                {% endfor %}
+            </select>
+        </label>
+        <label>Atostogų pabaiga
+            <input type="date" name="atostogu_pabaiga" value="{{ data.atostogu_pabaiga or '' }}">
+        </label>
+    </div>
+    <button type="submit">💾 Išsaugoti</button>
+    <a href="/vairuotojai">← Atgal</a>
 </form>
+<style>
+.form-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+}
+.form-grid label {
+    display: flex;
+    flex-direction: column;
+}
+</style>
 {% endblock %}

--- a/web_app/templates/vairuotojai_list.html
+++ b/web_app/templates/vairuotojai_list.html
@@ -1,7 +1,9 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2>Vairuotojai</h2>
-<a href="/vairuotojai/add">Pridėti naują</a>
+<div class="page-header">
+    <h2>Vairuotojų valdymas</h2>
+    <a class="add-btn" href="/vairuotojai/add">Pridėti vairuotoją</a>
+</div>
 <table id="drv-table" class="display" style="width:100%">
     <thead>
         <tr>
@@ -29,4 +31,12 @@ $(document).ready(function() {
     });
 });
 </script>
+<style>
+.page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+}
+</style>
 {% endblock %}


### PR DESCRIPTION
## Summary
- style driver listing with header and actions
- support driver nationality options in backend
- modernize driver form with dropdown and back link

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68659fe668108324b4a031b8b5b60db3