### PR TITLE
Update client management pages

### DIFF
--- a/web_app/templates/klientai_form.html
+++ b/web_app/templates/klientai_form.html
@@ -3,15 +3,71 @@
 <h2>{% if data.id %}Redaguoti klientą{% else %}Naujas klientas{% endif %}</h2>
 <form method="post" action="/klientai/save">
     <input type="hidden" name="cid" value="{{ data.id or 0 }}">
-    <label>Pavadinimas: <input type="text" name="pavadinimas" value="{{ data.pavadinimas or '' }}"></label><br>
-    <label>VAT numeris: <input type="text" name="vat_numeris" value="{{ data.vat_numeris or '' }}"></label><br>
-    <label>Kontaktinis asmuo: <input type="text" name="kontaktinis_asmuo" value="{{ data.kontaktinis_asmuo or '' }}"></label><br>
-    <label>Kontaktinis el. paštas: <input type="email" name="kontaktinis_el_pastas" value="{{ data.kontaktinis_el_pastas or '' }}"></label><br>
-    <label>Kontaktinis tel.: <input type="text" name="kontaktinis_tel" value="{{ data.kontaktinis_tel or '' }}"></label><br>
-    <label>COFACE limitas: <input type="number" step="any" name="coface_limitas" value="{{ data.coface_limitas or '' }}"></label><br>
-    <label>Įmonė: <input type="text" name="imone" value="{{ data.imone or '' }}"></label><br>
-    <label>Mūsų limitas: <input type="text" readonly value="{{ data.musu_limitas or '' }}"></label><br>
-    <label>Limito likutis: <input type="text" readonly value="{{ data.likes_limitas or '' }}"></label><br>
-    <button type="submit">Išsaugoti</button>
+    <input type="hidden" name="imone" value="{{ data.imone or '' }}">
+    <div class="form-grid">
+        <label>Įmonės pavadinimas
+            <input type="text" name="pavadinimas" value="{{ data.pavadinimas or '' }}">
+        </label>
+        <label>PVM/VAT numeris*
+            <input type="text" name="vat_numeris" value="{{ data.vat_numeris or '' }}">
+        </label>
+        <label>Kontaktinis asmuo
+            <input type="text" name="kontaktinis_asmuo" value="{{ data.kontaktinis_asmuo or '' }}">
+        </label>
+        <label>Kontaktinis el. paštas
+            <input type="email" name="kontaktinis_el_pastas" value="{{ data.kontaktinis_el_pastas or '' }}">
+        </label>
+        <label>Kontaktinis tel. nr.
+            <input type="text" name="kontaktinis_tel" value="{{ data.kontaktinis_tel or '' }}">
+        </label>
+        <label>Šalis
+            <select name="salis">
+                <option value=""></option>
+                {% for n, c in salys %}
+                <option value="{{ n }}" {% if n == data.salis %}selected{% endif %}>{{ n }}</option>
+                {% endfor %}
+            </select>
+        </label>
+        <label>Regionas
+            <input type="text" name="regionas" value="{{ data.regionas or '' }}">
+        </label>
+        <label>Miestas
+            <input type="text" name="miestas" value="{{ data.miestas or '' }}">
+        </label>
+        <label>Adresas
+            <input type="text" name="adresas" value="{{ data.adresas or '' }}">
+        </label>
+        <label>Sąskaitų kontaktinis asmuo
+            <input type="text" name="saskaitos_asmuo" value="{{ data.saskaitos_asmuo or '' }}">
+        </label>
+        <label>Sąskaitų el. paštas
+            <input type="email" name="saskaitos_el_pastas" value="{{ data.saskaitos_el_pastas or '' }}">
+        </label>
+        <label>Sąskaitų tel. nr.
+            <input type="text" name="saskaitos_tel" value="{{ data.saskaitos_tel or '' }}">
+        </label>
+        <label>COFACE limitas
+            <input type="number" step="any" name="coface_limitas" value="{{ data.coface_limitas or '' }}">
+        </label>
+        <label>Mūsų limitas (COFACE/3)
+            <input type="text" readonly value="{{ data.musu_limitas or '' }}">
+        </label>
+        <label>Limito likutis
+            <input type="text" readonly value="{{ data.likes_limitas or '' }}">
+        </label>
+    </div>
+    <button type="submit">💾 Išsaugoti</button>
+    <a href="/klientai">← Grįžti į sąrašą</a>
 </form>
+<style>
+.form-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+}
+.form-grid label {
+    display: flex;
+    flex-direction: column;
+}
+</style>
 {% endblock %}

--- a/web_app/templates/klientai_list.html
+++ b/web_app/templates/klientai_list.html
@@ -1,7 +1,9 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2>Klientai</h2>
-<a href="/klientai/add">Pridėti naują</a>
+<div class="page-header">
+    <h2>Klientai</h2>
+    <a class="add-btn" href="/klientai/add">Pridėti naują klientą</a>
+</div>
 <table id="cli-table" class="display" style="width:100%">
     <thead>
         <tr>
@@ -35,4 +37,12 @@ $(document).ready(function() {
     });
 });
 </script>
+<style>
+.page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+}
+</style>
 {% endblock %}


### PR DESCRIPTION
## Summary
- modernize client list and form pages
- compute credit limits in backend and expose EU country list
- extend `/klientai/save` to handle more fields

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6865a1539d5083248ceb387ca765b5fa