### PR TITLE
Fix role dependency usage

### DIFF
--- a/web_app/main.py
+++ b/web_app/main.py
@@ -261,7 +261,7 @@ def require_roles(*roles: Role):
         if not any(user_has_role(request, cursor, role) for role in roles):
             raise HTTPException(status_code=403, detail="Forbidden")
 
-    return Depends(wrapper)
+    return wrapper
 
 
 def get_db() -> Generator[tuple[sqlite3.Connection, sqlite3.Cursor], None, None]:


### PR DESCRIPTION
## Summary
- fix `require_roles` to return wrapper callable instead of a Depends object

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6865a8c8453483249736d98c4b80df21