### PR TITLE
Implement driver CRUD API

### DIFF
--- a/fastapi_app/app/crud.py
+++ b/fastapi_app/app/crud.py
@@ -178,3 +178,57 @@ def get_trucks(db: Session, tenant_id: UUID) -> list[models.Truck]:
         .order_by(models.Truck.id.desc())
         .all()
     )
+
+
+def create_driver(db: Session, tenant_id: UUID, data: schemas.DriverCreate) -> models.Driver:
+    driver = models.Driver(
+        tenant_id=tenant_id,
+        vardas=data.vardas,
+        pavarde=data.pavarde,
+        gimimo_metai=data.gimimo_metai,
+        tautybe=data.tautybe,
+        kadencijos_pabaiga=data.kadencijos_pabaiga,
+        atostogu_pabaiga=data.atostogu_pabaiga,
+    )
+    db.add(driver)
+    db.commit()
+    db.refresh(driver)
+    return driver
+
+
+def update_driver(db: Session, tenant_id: UUID, driver_id: int, data: schemas.DriverCreate) -> models.Driver | None:
+    driver = (
+        db.query(models.Driver)
+        .filter(models.Driver.id == driver_id, models.Driver.tenant_id == tenant_id)
+        .first()
+    )
+    if not driver:
+        return None
+    for field, value in data.dict().items():
+        setattr(driver, field, value)
+    db.commit()
+    db.refresh(driver)
+    return driver
+
+
+def delete_driver(db: Session, tenant_id: UUID, driver_id: int) -> bool:
+    driver = (
+        db.query(models.Driver)
+        .filter(models.Driver.id == driver_id, models.Driver.tenant_id == tenant_id)
+        .first()
+    )
+    if not driver:
+        return False
+    db.delete(driver)
+    db.commit()
+    return True
+
+
+def get_drivers(db: Session, tenant_id: UUID) -> list[models.Driver]:
+    return (
+        db.query(models.Driver)
+        .filter(models.Driver.tenant_id == tenant_id)
+        .order_by(models.Driver.id.desc())
+        .all()
+    )
+

--- a/fastapi_app/app/models.py
+++ b/fastapi_app/app/models.py
@@ -94,3 +94,18 @@ class Truck(Base):
     draudimas = Column(String)
 
     tenant = relationship("Tenant")
+
+
+class Driver(Base):
+    __tablename__ = "drivers"
+    id = Column(Integer, primary_key=True)
+    tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False)
+    vardas = Column(String, nullable=False)
+    pavarde = Column(String, nullable=False)
+    gimimo_metai = Column(String)
+    tautybe = Column(String)
+    kadencijos_pabaiga = Column(String)
+    atostogu_pabaiga = Column(String)
+
+    tenant = relationship("Tenant")
+

--- a/fastapi_app/app/schemas.py
+++ b/fastapi_app/app/schemas.py
@@ -126,3 +126,23 @@ class Truck(TruckBase):
 
     class Config:
         orm_mode = True
+
+
+class DriverBase(BaseModel):
+    vardas: str
+    pavarde: str
+    gimimo_metai: Optional[str] = None
+    tautybe: Optional[str] = None
+    kadencijos_pabaiga: Optional[str] = None
+    atostogu_pabaiga: Optional[str] = None
+
+class DriverCreate(DriverBase):
+    pass
+
+class Driver(DriverBase):
+    id: int
+    tenant_id: UUID
+
+    class Config:
+        orm_mode = True
+

--- a/fastapi_app/tests/test_drivers.py
+++ b/fastapi_app/tests/test_drivers.py
@@ -1,0 +1,78 @@
+import os
+os.environ.setdefault("SECRET_KEY", "test-secret")
+from fastapi.testclient import TestClient
+from fastapi_app.app.main import app
+from fastapi_app.app.auth import get_db, hash_password
+from fastapi_app.app.database import Base
+from fastapi_app.app import models
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+SQLALCHEMY_DATABASE_URL = "sqlite://"
+engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base.metadata.create_all(bind=engine)
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+app.dependency_overrides[get_db] = override_get_db
+client = TestClient(app)
+
+
+def setup_user():
+    with TestingSessionLocal() as db:
+        role = db.query(models.Role).filter(models.Role.name == "USER").first()
+        if not role:
+            role = models.Role(name="USER")
+            db.add(role)
+            db.commit()
+            db.refresh(role)
+        tenant = models.Tenant(name="t_driver")
+        user = models.User(email="driver@example.com", hashed_password=hash_password("pass"), full_name="Driver User")
+        assoc = models.UserTenant(user_id=user.id, tenant_id=tenant.id, role_id=role.id)
+        db.add_all([tenant, user, assoc])
+        db.commit()
+        db.refresh(tenant)
+        db.refresh(user)
+        return user, tenant
+
+
+def test_create_and_list_drivers():
+    user, tenant = setup_user()
+    resp = client.post("/auth/login", json={"email": user.email, "password": "pass", "tenant_id": str(tenant.id)})
+    token = resp.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    data = {"vardas": "Jonas", "pavarde": "Jonaitis"}
+    r = client.post(f"/{tenant.id}/drivers", json=data, headers=headers)
+    assert r.status_code == 200
+    did = r.json()["id"]
+
+    r2 = client.get(f"/{tenant.id}/drivers", headers=headers)
+    assert any(d["id"] == did for d in r2.json())
+
+
+def test_update_and_delete_driver():
+    user, tenant = setup_user()
+    login = client.post("/auth/login", json={"email": user.email, "password": "pass", "tenant_id": str(tenant.id)})
+    token = login.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    driver = {"vardas": "Petras", "pavarde": "Petraitis"}
+    r = client.post(f"/{tenant.id}/drivers", json=driver, headers=headers)
+    did = r.json()["id"]
+
+    upd = {"vardas": "Kazys", "pavarde": "Petraitis"}
+    r2 = client.put(f"/{tenant.id}/drivers/{did}", json=upd, headers=headers)
+    assert r2.status_code == 200
+    assert r2.json()["vardas"] == "Kazys"
+
+    r3 = client.delete(f"/{tenant.id}/drivers/{did}", headers=headers)
+    assert r3.status_code == 204


### PR DESCRIPTION
## Summary
- extend SQLAlchemy models with Driver
- add Driver Pydantic schemas
- create CRUD helpers for drivers
- expose `/drivers` endpoints in FastAPI app
- include new tests for driver operations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6865aa0d63e083248125432a3f6bd56e