### PR TITLE
Port trailer specs to FastAPI

### DIFF
--- a/fastapi_app/app/crud.py
+++ b/fastapi_app/app/crud.py
@@ -285,3 +285,35 @@ def get_trailers(db: Session, tenant_id: UUID) -> list[models.Trailer]:
         .all()
     )
 
+
+def create_trailer_spec(db: Session, data: schemas.TrailerSpecCreate) -> models.TrailerSpec:
+    spec = models.TrailerSpec(**data.dict())
+    db.add(spec)
+    db.commit()
+    db.refresh(spec)
+    return spec
+
+
+def update_trailer_spec(db: Session, spec_id: int, data: schemas.TrailerSpecCreate) -> models.TrailerSpec | None:
+    spec = db.query(models.TrailerSpec).filter(models.TrailerSpec.id == spec_id).first()
+    if not spec:
+        return None
+    for field, value in data.dict().items():
+        setattr(spec, field, value)
+    db.commit()
+    db.refresh(spec)
+    return spec
+
+
+def delete_trailer_spec(db: Session, spec_id: int) -> bool:
+    spec = db.query(models.TrailerSpec).filter(models.TrailerSpec.id == spec_id).first()
+    if not spec:
+        return False
+    db.delete(spec)
+    db.commit()
+    return True
+
+
+def get_trailer_specs(db: Session) -> list[models.TrailerSpec]:
+    return db.query(models.TrailerSpec).order_by(models.TrailerSpec.id.desc()).all()
+

--- a/fastapi_app/app/main.py
+++ b/fastapi_app/app/main.py
@@ -577,6 +577,49 @@ def delete_trailer(
     return Response(status_code=204)
 
 
+@app.post("/trailer-specs", response_model=schemas.TrailerSpec)
+def create_trailer_spec(
+    spec: schemas.TrailerSpecCreate,
+    current_user=Depends(dependencies.requires_roles(["SUPERADMIN"])),
+    db: Session = Depends(auth.get_db),
+):
+    created = crud.create_trailer_spec(db, spec)
+    return created
+
+
+@app.get("/trailer-specs", response_model=list[schemas.TrailerSpec])
+def read_trailer_specs(
+    current_user=Depends(auth.get_current_user),
+    db: Session = Depends(auth.get_db),
+):
+    return crud.get_trailer_specs(db)
+
+
+@app.put("/trailer-specs/{spec_id}", response_model=schemas.TrailerSpec)
+def update_trailer_spec(
+    spec_id: int,
+    spec: schemas.TrailerSpecCreate,
+    current_user=Depends(dependencies.requires_roles(["SUPERADMIN"])),
+    db: Session = Depends(auth.get_db),
+):
+    updated = crud.update_trailer_spec(db, spec_id, spec)
+    if not updated:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    return updated
+
+
+@app.delete("/trailer-specs/{spec_id}", status_code=204)
+def delete_trailer_spec(
+    spec_id: int,
+    current_user=Depends(dependencies.requires_roles(["SUPERADMIN"])),
+    db: Session = Depends(auth.get_db),
+):
+    ok = crud.delete_trailer_spec(db, spec_id)
+    if not ok:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    return Response(status_code=204)
+
+
 @app.post("/audit", response_model=schemas.AuditLog)
 def create_audit_entry(
     log: schemas.AuditLogCreate,

--- a/fastapi_app/app/models.py
+++ b/fastapi_app/app/models.py
@@ -125,3 +125,14 @@ class Trailer(Base):
 
     tenant = relationship("Tenant")
 
+
+class TrailerSpec(Base):
+    __tablename__ = "trailer_specs"
+    id = Column(Integer, primary_key=True)
+    tipas = Column(String, unique=True, nullable=False)
+    ilgis = Column(Integer)
+    plotis = Column(Integer)
+    aukstis = Column(Integer)
+    keliamoji_galia = Column(Integer)
+    talpa = Column(Integer)
+

--- a/fastapi_app/app/schemas.py
+++ b/fastapi_app/app/schemas.py
@@ -167,3 +167,23 @@ class Trailer(TrailerBase):
     class Config:
         orm_mode = True
 
+
+class TrailerSpecBase(BaseModel):
+    tipas: str
+    ilgis: Optional[int] = None
+    plotis: Optional[int] = None
+    aukstis: Optional[int] = None
+    keliamoji_galia: Optional[int] = None
+    talpa: Optional[int] = None
+
+
+class TrailerSpecCreate(TrailerSpecBase):
+    pass
+
+
+class TrailerSpec(TrailerSpecBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+

--- a/fastapi_app/tests/test_trailer_specs.py
+++ b/fastapi_app/tests/test_trailer_specs.py
@@ -1,0 +1,68 @@
+import os
+os.environ.setdefault("SECRET_KEY", "test-secret")
+from fastapi.testclient import TestClient
+from fastapi_app.app.main import app
+from fastapi_app.app.auth import get_db, hash_password
+from fastapi_app.app.database import Base
+from fastapi_app.app import models
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+SQLALCHEMY_DATABASE_URL = "sqlite://"
+engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base.metadata.create_all(bind=engine)
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+app.dependency_overrides[get_db] = override_get_db
+client = TestClient(app)
+
+
+def setup_user():
+    with TestingSessionLocal() as db:
+        role = db.query(models.Role).filter(models.Role.name == "SUPERADMIN").first()
+        if not role:
+            role = models.Role(name="SUPERADMIN")
+            db.add(role)
+            db.commit()
+            db.refresh(role)
+        tenant = models.Tenant(name="t_spec")
+        user = models.User(email="spec@example.com", hashed_password=hash_password("pass"), full_name="Spec User")
+        assoc = models.UserTenant(user_id=user.id, tenant_id=tenant.id, role_id=role.id)
+        db.add_all([tenant, user, assoc])
+        db.commit()
+        db.refresh(user)
+        db.refresh(tenant)
+        return user, tenant
+
+
+def test_crud_trailer_specs():
+    user, tenant = setup_user()
+    resp = client.post("/auth/login", json={"email": user.email, "password": "pass", "tenant_id": str(tenant.id)})
+    token = resp.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    data = {"tipas": "TypeA", "ilgis": 13}
+    r = client.post("/trailer-specs", json=data, headers=headers)
+    assert r.status_code == 200
+    spec_id = r.json()["id"]
+
+    r2 = client.get("/trailer-specs", headers=headers)
+    assert any(s["id"] == spec_id for s in r2.json())
+
+    upd = {"tipas": "TypeB"}
+    r3 = client.put(f"/trailer-specs/{spec_id}", json=upd, headers=headers)
+    assert r3.status_code == 200
+    assert r3.json()["tipas"] == "TypeB"
+
+    r4 = client.delete(f"/trailer-specs/{spec_id}", headers=headers)
+    assert r4.status_code == 204


### PR DESCRIPTION
## Summary
- prideta `TrailerSpec` modelis ir Pydantic schemos
- atnaujintas `crud.py` su funkcijomis `TrailerSpec`
- `main.py` prideti CRUD maršrutai `trailer-specs`
- sukurti testai `test_trailer_specs.py`

## Testing
- `pytest -q` *(nesėkminga: fastapi ir kiti paketai neįdiegti)*

------
https://chatgpt.com/codex/tasks/task_e_6865af9fd0c88324bb9bc1ea14c0b8a2