### PR TITLE
Pridėtas klientų valdymas FastAPI

### DIFF
--- a/fastapi_app/app/models.py
+++ b/fastapi_app/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, Integer, ForeignKey, Table, DateTime
+from sqlalchemy import Column, String, Integer, ForeignKey, Table, DateTime, Float
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 import uuid
@@ -153,6 +153,31 @@ class DefaultTrailerType(Base):
     tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False)
     value = Column(String, nullable=False)
     priority = Column(Integer, nullable=False, default=0)
+
+    tenant = relationship("Tenant")
+
+
+class Client(Base):
+    """Klientų lentelė"""
+
+    __tablename__ = "clients"
+    id = Column(Integer, primary_key=True)
+    tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False)
+    pavadinimas = Column(String, nullable=False)
+    vat_numeris = Column(String)
+    kontaktinis_asmuo = Column(String)
+    kontaktinis_el_pastas = Column(String)
+    kontaktinis_tel = Column(String)
+    salis = Column(String)
+    regionas = Column(String)
+    miestas = Column(String)
+    adresas = Column(String)
+    saskaitos_asmuo = Column(String)
+    saskaitos_el_pastas = Column(String)
+    saskaitos_tel = Column(String)
+    coface_limitas = Column(Float)
+    musu_limitas = Column(Float)
+    likes_limitas = Column(Float)
 
     tenant = relationship("Tenant")
 

--- a/fastapi_app/app/schemas.py
+++ b/fastapi_app/app/schemas.py
@@ -206,3 +206,34 @@ class TrailerType(TrailerTypeBase):
 class DefaultTrailerTypes(BaseModel):
     values: list[str]
 
+
+class ClientBase(BaseModel):
+    pavadinimas: str
+    vat_numeris: Optional[str] = None
+    kontaktinis_asmuo: Optional[str] = None
+    kontaktinis_el_pastas: Optional[str] = None
+    kontaktinis_tel: Optional[str] = None
+    salis: Optional[str] = None
+    regionas: Optional[str] = None
+    miestas: Optional[str] = None
+    adresas: Optional[str] = None
+    saskaitos_asmuo: Optional[str] = None
+    saskaitos_el_pastas: Optional[str] = None
+    saskaitos_tel: Optional[str] = None
+    coface_limitas: Optional[float] = 0
+
+
+class ClientCreate(ClientBase):
+    pass
+
+
+class Client(ClientBase):
+    id: int
+    tenant_id: UUID
+
+    musu_limitas: Optional[float] = None
+    likes_limitas: Optional[float] = None
+
+    class Config:
+        orm_mode = True
+

--- a/fastapi_app/tests/test_clients.py
+++ b/fastapi_app/tests/test_clients.py
@@ -1,0 +1,71 @@
+import os
+os.environ.setdefault("SECRET_KEY", "test-secret")
+from fastapi.testclient import TestClient
+from fastapi_app.app.main import app
+from fastapi_app.app.auth import get_db, hash_password
+from fastapi_app.app.database import Base
+from fastapi_app.app import models
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+SQLALCHEMY_DATABASE_URL = "sqlite://"
+engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base.metadata.create_all(bind=engine)
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+app.dependency_overrides[get_db] = override_get_db
+client = TestClient(app)
+
+
+def setup_user():
+    with TestingSessionLocal() as db:
+        role = db.query(models.Role).filter(models.Role.name == "USER").first()
+        if not role:
+            role = models.Role(name="USER")
+            db.add(role)
+            db.commit()
+            db.refresh(role)
+        tenant = models.Tenant(name="t_client")
+        user = models.User(email="client@example.com", hashed_password=hash_password("pass"), full_name="Client User")
+        assoc = models.UserTenant(user_id=user.id, tenant_id=tenant.id, role_id=role.id)
+        db.add_all([tenant, user, assoc])
+        db.commit()
+        db.refresh(user)
+        db.refresh(tenant)
+        return user, tenant
+
+
+def test_crud_clients():
+    user, tenant = setup_user()
+    resp = client.post("/auth/login", json={"email": user.email, "password": "pass", "tenant_id": str(tenant.id)})
+    token = resp.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    data = {"pavadinimas": "ACME", "coface_limitas": 900}
+    r = client.post(f"/{tenant.id}/clients", json=data, headers=headers)
+    assert r.status_code == 200
+    cid = r.json()["id"]
+    assert r.json()["musu_limitas"] == 300
+
+    r2 = client.get(f"/{tenant.id}/clients", headers=headers)
+    assert any(c["id"] == cid for c in r2.json())
+
+    upd = {"pavadinimas": "ACME2", "coface_limitas": 600}
+    r3 = client.put(f"/{tenant.id}/clients/{cid}", json=upd, headers=headers)
+    assert r3.status_code == 200
+    assert r3.json()["pavadinimas"] == "ACME2"
+
+    r4 = client.delete(f"/{tenant.id}/clients/{cid}", headers=headers)
+    assert r4.status_code == 204
+    r5 = client.get(f"/{tenant.id}/clients", headers=headers)
+    assert all(c["id"] != cid for c in r5.json())


### PR DESCRIPTION
## Santrauka
- Sukurtas `Client` modelis ir Pydantic schemos
- Į `crud.py` įtrauktos funkcijos klientų kūrimui, atnaujinimui ir šalinimui
- `main.py` pridėti REST maršrutai klientams ir auditui
- Sukurtas testas `test_clients.py`

## Testai
- `pytest -q` **nepavyko** dėl trūkstamų priklausomybių (`fastapi` ir kt.)


------
https://chatgpt.com/codex/tasks/task_e_6865b3993378832488d02b16d2399950