### PR TITLE
Pridėti CSV eksportavimo galimybes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains a Streamlit based application for logistics companies. The app manages shipments, vehicles and staff information in a single dashboard and stores all data in a local SQLite database.
 
-Besides the Streamlit UI, the repository now provides an alternative FastAPI based web interface located in the `web_app` directory. This interface relies on DataTables for an Excel-style look and can be started locally without Streamlit. Initially it only supported shipment management but now also includes trucks, trailers, employees, groups, clients, drivers, trailer type management and an audit log section and a simple login/registration system.
+Besides the Streamlit UI, the repository now provides an alternative FastAPI based web interface located in the `web_app` directory. This interface relies on DataTables for an Excel-style look and can be started locally without Streamlit. Initially it only supported shipment management but now also includes trucks, trailers, employees, groups, clients, drivers, trailer type management and an audit log section and a simple login/registration system. Naujausioje versijoje taip pat galima atsisiųsti darbuotojų, grupių, klientų, vairuotojų bei priekabų specifikacijų sąrašus CSV formatu.
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- pridėta `table_csv_response` funkcija bendrai CSV generacijai
- nauji `/api/<modulis>.csv` maršrutai darbuotojams, grupėms, klientams, vairuotojams, priekabų tipams ir specifikacijoms
- atnaujintas README aprašant papildomas CSV eksporto galimybes

## Testing
- `pytest -q` *(failed: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6865b55fa2348324ba2bddc6776e921c