### PR TITLE
Handle empty planavimas response

### DIFF
--- a/web_app/templates/planavimas.html
+++ b/web_app/templates/planavimas.html
@@ -4,9 +4,14 @@
 <table id="plan-table" class="display" style="width:100%"></table>
 <script>
 $(document).ready(function() {
+    var $table = $('#plan-table');
     $.getJSON('/api/planavimas', function(resp) {
+        if (!resp.data || resp.data.length === 0) {
+            $table.replaceWith('<p>Šiuo laikotarpiu įrašų nėra</p>');
+            return;
+        }
         var cols = resp.columns.map(function(c) { return {data: c, title: c}; });
-        $('#plan-table').DataTable({
+        $table.DataTable({
             data: resp.data,
             columns: cols,
             ordering: false


### PR DESCRIPTION
## Summary
- show a notice when `/api/planavimas` returns no rows

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6865b6f357b08324b8bca6a997f6335a