### PR TITLE
Update updates module

### DIFF
--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -438,6 +438,7 @@ def test_updates_basic(tmp_path):
         "data": "2023-01-01",
         "darbo_laikas": "8",
         "likes_laikas": "4",
+        "sa": "SA",
         "pakrovimo_statusas": "Pakrauta",
         "pakrovimo_laikas": "10:00",
         "pakrovimo_data": "2023-01-01",
@@ -453,6 +454,7 @@ def test_updates_basic(tmp_path):
     data = resp.json()["data"]
     assert len(data) == 1
     assert data[0]["vilkiko_numeris"] == "AAA111"
+    assert data[0]["sa"] == "SA"
 
     resp = client.get("/api/updates.csv")
     assert resp.status_code == 200

--- a/web_app/main.py
+++ b/web_app/main.py
@@ -1786,6 +1786,7 @@ def updates_save(
     data: str = Form(...),
     darbo_laikas: int = Form(0),
     likes_laikas: int = Form(0),
+    sa: str = Form(""),
     pakrovimo_statusas: str = Form(""),
     pakrovimo_laikas: str = Form(""),
     pakrovimo_data: str = Form(""),
@@ -1796,12 +1797,14 @@ def updates_save(
     db: tuple[sqlite3.Connection, sqlite3.Cursor] = Depends(get_db),
 ):
     conn, cursor = db
+    now_str = datetime.datetime.now().replace(second=0, microsecond=0).isoformat(timespec="minutes")
     if uid:
         cursor.execute(
-            "UPDATE vilkiku_darbo_laikai SET vilkiko_numeris=?, data=?, darbo_laikas=?, likes_laikas=?, pakrovimo_statusas=?, pakrovimo_laikas=?, pakrovimo_data=?, iskrovimo_statusas=?, iskrovimo_laikas=?, iskrovimo_data=?, komentaras=? WHERE id=?",
+            "UPDATE vilkiku_darbo_laikai SET vilkiko_numeris=?, data=?, sa=?, darbo_laikas=?, likes_laikas=?, pakrovimo_statusas=?, pakrovimo_laikas=?, pakrovimo_data=?, iskrovimo_statusas=?, iskrovimo_laikas=?, iskrovimo_data=?, komentaras=?, created_at=? WHERE id=?",
             (
                 vilkiko_numeris,
                 data,
+                sa,
                 darbo_laikas,
                 likes_laikas,
                 pakrovimo_statusas,
@@ -1811,16 +1814,18 @@ def updates_save(
                 iskrovimo_laikas,
                 iskrovimo_data,
                 komentaras,
+                now_str,
                 uid,
             ),
         )
         action = "update"
     else:
         cursor.execute(
-            "INSERT INTO vilkiku_darbo_laikai (vilkiko_numeris, data, darbo_laikas, likes_laikas, pakrovimo_statusas, pakrovimo_laikas, pakrovimo_data, iskrovimo_statusas, iskrovimo_laikas, iskrovimo_data, komentaras) VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+            "INSERT INTO vilkiku_darbo_laikai (vilkiko_numeris, data, sa, darbo_laikas, likes_laikas, pakrovimo_statusas, pakrovimo_laikas, pakrovimo_data, iskrovimo_statusas, iskrovimo_laikas, iskrovimo_data, komentaras, created_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
             (
                 vilkiko_numeris,
                 data,
+                sa,
                 darbo_laikas,
                 likes_laikas,
                 pakrovimo_statusas,
@@ -1830,6 +1835,7 @@ def updates_save(
                 iskrovimo_laikas,
                 iskrovimo_data,
                 komentaras,
+                now_str,
             ),
         )
         uid = cursor.lastrowid

--- a/web_app/templates/updates_form.html
+++ b/web_app/templates/updates_form.html
@@ -7,13 +7,30 @@
     <label>Data: <input type="date" name="data" value="{{ data.data or '' }}"></label><br>
     <label>Darbo laikas: <input type="number" name="darbo_laikas" value="{{ data.darbo_laikas or 0 }}"></label><br>
     <label>Likusios valandos: <input type="number" name="likes_laikas" value="{{ data.likes_laikas or 0 }}"></label><br>
+    <label>SA: <input type="text" name="sa" value="{{ data.sa or '' }}"></label><br>
     <label>Pakrovimo statusas: <input type="text" name="pakrovimo_statusas" value="{{ data.pakrovimo_statusas or '' }}"></label><br>
-    <label>Pakrovimo laikas: <input type="text" name="pakrovimo_laikas" value="{{ data.pakrovimo_laikas or '' }}"></label><br>
+    <label>Pakrovimo laikas: <input class="time" type="text" name="pakrovimo_laikas" value="{{ data.pakrovimo_laikas or '' }}" placeholder="HHMM"></label><br>
     <label>Pakrovimo data: <input type="date" name="pakrovimo_data" value="{{ data.pakrovimo_data or '' }}"></label><br>
     <label>Iškrovimo statusas: <input type="text" name="iskrovimo_statusas" value="{{ data.iskrovimo_statusas or '' }}"></label><br>
-    <label>Iškrovimo laikas: <input type="text" name="iskrovimo_laikas" value="{{ data.iskrovimo_laikas or '' }}"></label><br>
+    <label>Iškrovimo laikas: <input class="time" type="text" name="iskrovimo_laikas" value="{{ data.iskrovimo_laikas or '' }}" placeholder="HHMM"></label><br>
     <label>Iškrovimo data: <input type="date" name="iskrovimo_data" value="{{ data.iskrovimo_data or '' }}"></label><br>
     <label>Komentaras: <input type="text" name="komentaras" value="{{ data.komentaras or '' }}"></label><br>
     <button type="submit">Išsaugoti</button>
 </form>
+<script>
+function formatTime(val) {
+    if (!val) return '';
+    var digits = String(val).replace(/\D/g, '');
+    if (digits.length === 1) return '0' + digits + ':00';
+    if (digits.length === 2) return digits.padStart(2, '0') + ':00';
+    if (digits.length === 3) return '0' + digits[0] + ':' + digits.slice(1).padStart(2, '0');
+    if (digits.length === 4) return digits.slice(0, 2) + ':' + digits.slice(2);
+    return val;
+}
+document.querySelectorAll('input.time').forEach(function(el){
+    el.addEventListener('blur', function(){
+        this.value = formatTime(this.value);
+    });
+});
+</script>
 {% endblock %}

--- a/web_app/templates/updates_list.html
+++ b/web_app/templates/updates_list.html
@@ -8,9 +8,17 @@
             <th>ID</th>
             <th>Vilkikas</th>
             <th>Data</th>
+            <th>SA</th>
             <th>Darbo laikas</th>
             <th>Likusios val.</th>
+            <th>P. data</th>
+            <th>P. laikas</th>
+            <th>P. statusas</th>
+            <th>I. data</th>
+            <th>I. laikas</th>
+            <th>I. statusas</th>
             <th>Komentaras</th>
+            <th>Atnaujinta prieš</th>
             <th>Veiksmai</th>
         </tr>
     </thead>
@@ -23,14 +31,42 @@ $(document).ready(function() {
             { data: 'id' },
             { data: 'vilkiko_numeris' },
             { data: 'data' },
+            { data: 'sa' },
             { data: 'darbo_laikas' },
             { data: 'likes_laikas' },
+            { data: 'pakrovimo_data' },
+            { data: 'pakrovimo_laikas', render: function(d){return formatTime(d);} },
+            { data: 'pakrovimo_statusas' },
+            { data: 'iskrovimo_data' },
+            { data: 'iskrovimo_laikas', render: function(d){return formatTime(d);} },
+            { data: 'iskrovimo_statusas' },
             { data: 'komentaras' },
+            { data: 'created_at', render: function(d){return relativeTime(d);} },
             { data: null, render: function(data, type, row) {
                 return '<a href="/updates/' + row.id + '/edit">Edit</a>';
             }}
         ]
     });
 });
+
+function formatTime(val) {
+    if (!val) return '';
+    var digits = String(val).replace(/\D/g, '');
+    if (digits.length === 1) return '0' + digits + ':00';
+    if (digits.length === 2) return digits.padStart(2, '0') + ':00';
+    if (digits.length === 3) return '0' + digits[0] + ':' + digits.slice(1).padStart(2, '0');
+    if (digits.length === 4) return digits.slice(0, 2) + ':' + digits.slice(2);
+    return val;
+}
+
+function relativeTime(ts) {
+    if (!ts) return '';
+    var created = new Date(ts);
+    var now = new Date();
+    var diff = Math.floor((now - created) / 60000);
+    var hrs = String(Math.floor(diff / 60)).padStart(2, '0');
+    var mins = String(diff % 60).padStart(2, '0');
+    return hrs + ':' + mins;
+}
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- extend updates table/list templates with more fields and time helpers
- include SA and time formatting in updates form
- store SA and timestamp when saving updates
- cover extra field in web app test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6865b8da803883249fdd989109ab5928