### PR TITLE
Pridetas grupiu API

### DIFF
--- a/fastapi_app/app/crud.py
+++ b/fastapi_app/app/crud.py
@@ -446,3 +446,53 @@ def get_clients(db: Session, tenant_id: UUID) -> list[models.Client]:
         .all()
     )
 
+
+def create_group(db: Session, tenant_id: UUID, data: schemas.GroupCreate) -> models.Group:
+    group = models.Group(
+        tenant_id=tenant_id,
+        numeris=data.numeris,
+        pavadinimas=data.pavadinimas,
+        aprasymas=data.aprasymas,
+    )
+    db.add(group)
+    db.commit()
+    db.refresh(group)
+    return group
+
+
+def update_group(db: Session, tenant_id: UUID, group_id: int, data: schemas.GroupCreate) -> models.Group | None:
+    group = (
+        db.query(models.Group)
+        .filter(models.Group.id == group_id, models.Group.tenant_id == tenant_id)
+        .first()
+    )
+    if not group:
+        return None
+    for field, value in data.dict().items():
+        setattr(group, field, value)
+    db.commit()
+    db.refresh(group)
+    return group
+
+
+def delete_group(db: Session, tenant_id: UUID, group_id: int) -> bool:
+    group = (
+        db.query(models.Group)
+        .filter(models.Group.id == group_id, models.Group.tenant_id == tenant_id)
+        .first()
+    )
+    if not group:
+        return False
+    db.delete(group)
+    db.commit()
+    return True
+
+
+def get_groups(db: Session, tenant_id: UUID) -> list[models.Group]:
+    return (
+        db.query(models.Group)
+        .filter(models.Group.tenant_id == tenant_id)
+        .order_by(models.Group.id.desc())
+        .all()
+    )
+

--- a/fastapi_app/app/models.py
+++ b/fastapi_app/app/models.py
@@ -181,3 +181,16 @@ class Client(Base):
 
     tenant = relationship("Tenant")
 
+
+class Group(Base):
+    """Darbuotojų ar transporto grupė"""
+
+    __tablename__ = "groups"
+    id = Column(Integer, primary_key=True)
+    tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False)
+    numeris = Column(String, nullable=False)
+    pavadinimas = Column(String)
+    aprasymas = Column(String)
+
+    tenant = relationship("Tenant")
+

--- a/fastapi_app/app/schemas.py
+++ b/fastapi_app/app/schemas.py
@@ -237,3 +237,22 @@ class Client(ClientBase):
     class Config:
         orm_mode = True
 
+
+class GroupBase(BaseModel):
+    numeris: str
+    pavadinimas: Optional[str] = None
+    aprasymas: Optional[str] = None
+
+
+class GroupCreate(GroupBase):
+    pass
+
+
+class Group(GroupBase):
+    id: int
+    tenant_id: UUID
+
+    class Config:
+        orm_mode = True
+
+

--- a/fastapi_app/tests/test_groups.py
+++ b/fastapi_app/tests/test_groups.py
@@ -1,0 +1,69 @@
+import os
+os.environ.setdefault("SECRET_KEY", "test-secret")
+from fastapi.testclient import TestClient
+from fastapi_app.app.main import app
+from fastapi_app.app.auth import get_db, hash_password
+from fastapi_app.app.database import Base
+from fastapi_app.app import models
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+SQLALCHEMY_DATABASE_URL = "sqlite://"
+engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base.metadata.create_all(bind=engine)
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+app.dependency_overrides[get_db] = override_get_db
+client = TestClient(app)
+
+
+def setup_user():
+    with TestingSessionLocal() as db:
+        role = db.query(models.Role).filter(models.Role.name == "USER").first()
+        if not role:
+            role = models.Role(name="USER")
+            db.add(role)
+            db.commit()
+            db.refresh(role)
+        tenant = models.Tenant(name="t_group")
+        user = models.User(email="group@example.com", hashed_password=hash_password("pass"), full_name="Group User")
+        assoc = models.UserTenant(user_id=user.id, tenant_id=tenant.id, role_id=role.id)
+        db.add_all([tenant, user, assoc])
+        db.commit()
+        db.refresh(user)
+        db.refresh(tenant)
+        return user, tenant
+
+
+def test_crud_groups():
+    user, tenant = setup_user()
+    resp = client.post("/auth/login", json={"email": user.email, "password": "pass", "tenant_id": str(tenant.id)})
+    token = resp.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    data = {"numeris": "TR1", "pavadinimas": "Test"}
+    r = client.post(f"/{tenant.id}/groups", json=data, headers=headers)
+    assert r.status_code == 200
+    gid = r.json()["id"]
+
+    r2 = client.get(f"/{tenant.id}/groups", headers=headers)
+    assert any(g["id"] == gid for g in r2.json())
+
+    upd = {"numeris": "TR2", "pavadinimas": "Upd"}
+    r3 = client.put(f"/{tenant.id}/groups/{gid}", json=upd, headers=headers)
+    assert r3.status_code == 200
+    assert r3.json()["numeris"] == "TR2"
+
+    r4 = client.delete(f"/{tenant.id}/groups/{gid}", headers=headers)
+    assert r4.status_code == 204
+


### PR DESCRIPTION
## Atlikta
1. FastAPI `models.py` pridėjau `Group` modelį.
2. `schemas.py` papildyti atitinkamais Pydantic modeliais.
3. `crud.py` parašytos grupių CRUD funkcijos.
4. `main.py` sukurti `/groups` maršrutai (POST/GET/PUT/DELETE) su audit log'u.
5. Sukurtas testas `test_groups.py`.

## Planuojama
- Perkelti darbuotojų bei kitų modulių funkcijas į FastAPI.
- Išplėsti grupių funkcionalumą (regionų priskyrimas).


------
https://chatgpt.com/codex/tasks/task_e_6866624bf918832486e43bc95be9cbc5