### PR TITLE
Tęsti migraciją į FastAPI – pridėtas updates modulis

### DIFF
--- a/fastapi_app/app/crud.py
+++ b/fastapi_app/app/crud.py
@@ -496,3 +496,48 @@ def get_groups(db: Session, tenant_id: UUID) -> list[models.Group]:
         .all()
     )
 
+
+def create_update(db: Session, tenant_id: UUID, data: schemas.UpdateCreate) -> models.UpdateEntry:
+    entry = models.UpdateEntry(tenant_id=tenant_id, **data.dict())
+    db.add(entry)
+    db.commit()
+    db.refresh(entry)
+    return entry
+
+
+def update_update(db: Session, tenant_id: UUID, update_id: int, data: schemas.UpdateCreate) -> models.UpdateEntry | None:
+    entry = (
+        db.query(models.UpdateEntry)
+        .filter(models.UpdateEntry.id == update_id, models.UpdateEntry.tenant_id == tenant_id)
+        .first()
+    )
+    if not entry:
+        return None
+    for field, value in data.dict().items():
+        setattr(entry, field, value)
+    db.commit()
+    db.refresh(entry)
+    return entry
+
+
+def delete_update(db: Session, tenant_id: UUID, update_id: int) -> bool:
+    entry = (
+        db.query(models.UpdateEntry)
+        .filter(models.UpdateEntry.id == update_id, models.UpdateEntry.tenant_id == tenant_id)
+        .first()
+    )
+    if not entry:
+        return False
+    db.delete(entry)
+    db.commit()
+    return True
+
+
+def get_updates(db: Session, tenant_id: UUID) -> list[models.UpdateEntry]:
+    return (
+        db.query(models.UpdateEntry)
+        .filter(models.UpdateEntry.tenant_id == tenant_id)
+        .order_by(models.UpdateEntry.id.desc())
+        .all()
+    )
+

--- a/fastapi_app/app/models.py
+++ b/fastapi_app/app/models.py
@@ -194,3 +194,30 @@ class Group(Base):
 
     tenant = relationship("Tenant")
 
+
+class UpdateEntry(Base):
+    """Vilkikų darbo laiko įrašai"""
+
+    __tablename__ = "updates"
+    id = Column(Integer, primary_key=True)
+    tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False)
+    vilkiko_numeris = Column(String, nullable=False)
+    data = Column(String, nullable=False)
+    darbo_laikas = Column(Integer)
+    likes_laikas = Column(Integer)
+    pakrovimo_statusas = Column(String)
+    pakrovimo_laikas = Column(String)
+    pakrovimo_data = Column(String)
+    iskrovimo_statusas = Column(String)
+    iskrovimo_laikas = Column(String)
+    iskrovimo_data = Column(String)
+    komentaras = Column(String)
+    sa = Column(String)
+    created_at = Column(String)
+    ats_transporto_vadybininkas = Column(String)
+    ats_ekspedicijos_vadybininkas = Column(String)
+    trans_grupe = Column(String)
+    eksp_grupe = Column(String)
+
+    tenant = relationship("Tenant")
+

--- a/fastapi_app/app/schemas.py
+++ b/fastapi_app/app/schemas.py
@@ -256,3 +256,35 @@ class Group(GroupBase):
         orm_mode = True
 
 
+class UpdateBase(BaseModel):
+    vilkiko_numeris: str
+    data: str
+    darbo_laikas: Optional[int] = None
+    likes_laikas: Optional[int] = None
+    pakrovimo_statusas: Optional[str] = None
+    pakrovimo_laikas: Optional[str] = None
+    pakrovimo_data: Optional[str] = None
+    iskrovimo_statusas: Optional[str] = None
+    iskrovimo_laikas: Optional[str] = None
+    iskrovimo_data: Optional[str] = None
+    komentaras: Optional[str] = None
+    sa: Optional[str] = None
+    created_at: Optional[str] = None
+    ats_transporto_vadybininkas: Optional[str] = None
+    ats_ekspedicijos_vadybininkas: Optional[str] = None
+    trans_grupe: Optional[str] = None
+    eksp_grupe: Optional[str] = None
+
+
+class UpdateCreate(UpdateBase):
+    pass
+
+
+class Update(UpdateBase):
+    id: int
+    tenant_id: UUID
+
+    class Config:
+        orm_mode = True
+
+

--- a/fastapi_app/tests/test_updates.py
+++ b/fastapi_app/tests/test_updates.py
@@ -1,0 +1,81 @@
+import os
+import uuid
+os.environ.setdefault("SECRET_KEY", "test-secret")
+from fastapi.testclient import TestClient
+from fastapi_app.app.main import app
+from fastapi_app.app.auth import get_db, hash_password
+from fastapi_app.app.database import Base
+from fastapi_app.app import models
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+SQLALCHEMY_DATABASE_URL = "sqlite://"
+engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base.metadata.create_all(bind=engine)
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+app.dependency_overrides[get_db] = override_get_db
+client = TestClient(app)
+
+
+def setup_user():
+    with TestingSessionLocal() as db:
+        role = db.query(models.Role).filter(models.Role.name == "USER").first()
+        if not role:
+            role = models.Role(name="USER")
+            db.add(role)
+            db.commit()
+            db.refresh(role)
+        tenant = models.Tenant(name="t_updates")
+        user = models.User(email="up@example.com", hashed_password=hash_password("pass"), full_name="Upd User")
+        assoc = models.UserTenant(user_id=user.id, tenant_id=tenant.id, role_id=role.id)
+        db.add_all([tenant, user, assoc])
+        db.commit()
+        db.refresh(tenant)
+        db.refresh(user)
+        return user, tenant
+
+
+def test_create_and_list_updates():
+    user, tenant = setup_user()
+    resp = client.post("/auth/login", json={"email": user.email, "password": "pass", "tenant_id": str(tenant.id)})
+    assert resp.status_code == 200
+    token = resp.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    data = {"vilkiko_numeris": "AAA111", "data": "2025-01-01"}
+    r = client.post(f"/{tenant.id}/updates", json=data, headers=headers)
+    assert r.status_code == 200
+    uid = r.json()["id"]
+
+    r2 = client.get(f"/{tenant.id}/updates", headers=headers)
+    assert any(u["id"] == uid for u in r2.json())
+
+
+def test_update_and_delete_updates():
+    user, tenant = setup_user()
+    login = client.post("/auth/login", json={"email": user.email, "password": "pass", "tenant_id": str(tenant.id)})
+    token = login.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    upd = {"vilkiko_numeris": "BBB222", "data": "2025-01-02"}
+    r = client.post(f"/{tenant.id}/updates", json=upd, headers=headers)
+    uid = r.json()["id"]
+
+    change = upd | {"komentaras": "test"}
+    r2 = client.put(f"/{tenant.id}/updates/{uid}", json=change, headers=headers)
+    assert r2.status_code == 200
+    assert r2.json()["komentaras"] == "test"
+
+    r3 = client.delete(f"/{tenant.id}/updates/{uid}", headers=headers)
+    assert r3.status_code == 204


### PR DESCRIPTION
## Summary
- FastAPI `models.py` papildytas `UpdateEntry` lentele
- `schemas.py` pridėtos `Update*` schemos
- `crud.py` sukurtos operacijos `create_update`, `update_update`, `delete_update`, `get_updates`
- `main.py` registruotos naujos `/updates` maršrutų funkcijos su auditu
- pridėti testai `test_updates.py`

## Testing
- `pytest -q fastapi_app/tests/test_updates.py -q` *(nepavyko paleisti dėl trūkstamų priklausomybių)*

------
https://chatgpt.com/codex/tasks/task_e_6866644a5e408324ac55e5d350e55d43