### PR TITLE
FastAPI endpoint for EU countries

### DIFF
--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -482,3 +482,12 @@ def test_klientai_limits(tmp_path):
     row = data[0]
     assert row["musu_limitas"] == 300
     assert row["likes_limitas"] == 300
+
+
+def test_eu_countries(tmp_path):
+    client = create_client(tmp_path)
+    resp = client.get("/api/eu-countries")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert any(c["code"] == "LT" for c in data)
+

--- a/web_app/main.py
+++ b/web_app/main.py
@@ -61,6 +61,18 @@ app.mount("/static", StaticFiles(directory="web_app/static"), name="static")
 templates = Jinja2Templates(directory="web_app/templates")
 
 
+@app.get("/api/eu-countries")
+def eu_countries():
+    """Grąžina Europos šalių sąrašą."""
+    return {
+        "data": [
+            {"name": name, "code": code}
+            for name, code in EU_COUNTRIES
+            if name
+        ]
+    }
+
+
 def table_csv_response(cursor: sqlite3.Cursor, table: str, filename: str) -> Response:
     """Sukurti CSV atsakymą visos lentelės duomenims."""
     cursor.execute(f"SELECT * FROM {table}")


### PR DESCRIPTION
## Summary
- pridėtas `/api/eu-countries` maršrutas grąžinantis Europos šalis
- atnaujintas `tests/test_web_app.py` su nauju testu

## Testing
- `pytest tests/test_web_app.py::test_eu_countries -q` *(failed: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68666ab10dac8324b4c3c2f8b1ce4430