### PR TITLE
Tęsiama migracija į FastAPI – pridėtas EU šalių API

### DIFF
--- a/fastapi_app/app/main.py
+++ b/fastapi_app/app/main.py
@@ -16,6 +16,7 @@ import pandas as pd
 from . import models, schemas, crud, auth, dependencies
 from .database import Base
 import json
+from modules.constants import EU_COUNTRIES
 
 limiter = Limiter(key_func=get_remote_address)
 app = FastAPI()
@@ -1075,3 +1076,11 @@ def read_audit_csv(
     csv_data = df.to_csv(index=False)
     headers = {"Content-Disposition": "attachment; filename=audit.csv"}
     return Response(content=csv_data, media_type="text/csv", headers=headers)
+
+
+@app.get("/eu-countries")
+def eu_countries_api():
+    """Grąžina Europos šalių sąrašą."""
+    return {
+        "data": [{"name": name, "code": code} for name, code in EU_COUNTRIES if name]
+    }

--- a/fastapi_app/tests/test_eu_countries.py
+++ b/fastapi_app/tests/test_eu_countries.py
@@ -1,0 +1,13 @@
+import os
+os.environ.setdefault("SECRET_KEY", "test-secret")
+from fastapi.testclient import TestClient
+from fastapi_app.app.main import app
+
+client = TestClient(app)
+
+
+def test_eu_countries_endpoint():
+    resp = client.get("/eu-countries")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert any(c["code"] == "LT" for c in data)


### PR DESCRIPTION
## Atlikta
1. `fastapi_app/app/main.py` pridėtas `EU_COUNTRIES` importas ir naujas `/eu-countries` endpointas.
2. Sukurtas testas `fastapi_app/tests/test_eu_countries.py` patikrinantis, kad grąžinamas šalių sąrašas su LT kodu.

## Planai
- Toliau perkelti likusias Streamlit funkcijas į FastAPI.
- Išplėsti FastAPI testus papildomais moduliais.


------
https://chatgpt.com/codex/tasks/task_e_68666e05978c8324b4cdb11bbf0fa081