### PR TITLE
Perkelta registracijos logika į FastAPI

### DIFF
--- a/fastapi_app/app/auth.py
+++ b/fastapi_app/app/auth.py
@@ -41,7 +41,7 @@ def verify_password(password: str, hashed: str) -> bool:
 
 def authenticate_user(db: Session, email: str, password: str):
     user = db.query(models.User).filter(models.User.email == email).first()
-    if not user or not verify_password(password, user.hashed_password):
+    if not user or not verify_password(password, user.hashed_password) or not user.is_active:
         return None
     return user
 

--- a/fastapi_app/app/crud.py
+++ b/fastapi_app/app/crud.py
@@ -6,11 +6,12 @@ import json
 from datetime import datetime
 
 
-def create_user(db: Session, user: schemas.UserCreate) -> models.User:
+def create_user(db: Session, user: schemas.UserCreate, active: bool = True) -> models.User:
     db_user = models.User(
         email=user.email,
         hashed_password=auth.hash_password(user.password),
         full_name=user.full_name,
+        is_active=active,
     )
     db.add(db_user)
     db.commit()

--- a/fastapi_app/app/models.py
+++ b/fastapi_app/app/models.py
@@ -20,6 +20,7 @@ class User(Base):
     email = Column(String, unique=True, nullable=False)
     hashed_password = Column(String, nullable=False)
     full_name = Column(String)
+    is_active = Column(Boolean, nullable=False, default=True)
     tenants = relationship("UserTenant", back_populates="user")
 
 

--- a/fastapi_app/app/schemas.py
+++ b/fastapi_app/app/schemas.py
@@ -39,6 +39,7 @@ class UserCreate(UserBase):
 
 class User(UserBase):
     id: UUID
+    is_active: bool = True
 
     class Config:
         orm_mode = True

--- a/fastapi_app/tests/test_registration.py
+++ b/fastapi_app/tests/test_registration.py
@@ -1,0 +1,74 @@
+import uuid
+import os
+os.environ.setdefault("SECRET_KEY", "test-secret")
+from fastapi.testclient import TestClient
+from fastapi_app.app.main import app
+from fastapi_app.app.auth import get_db, hash_password
+from fastapi_app.app.database import Base
+from fastapi_app.app import models
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+SQLALCHEMY_DATABASE_URL = "sqlite://"
+engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base.metadata.create_all(bind=engine)
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+app.dependency_overrides[get_db] = override_get_db
+client = TestClient(app)
+
+
+def setup_superadmin():
+    with TestingSessionLocal() as db:
+        sa_role = db.query(models.Role).filter(models.Role.name == "SUPERADMIN").first()
+        user_role = db.query(models.Role).filter(models.Role.name == "USER").first()
+        if not sa_role:
+            sa_role = models.Role(name="SUPERADMIN")
+            db.add(sa_role)
+        if not user_role:
+            user_role = models.Role(name="USER")
+            db.add(user_role)
+        tenant = models.Tenant(name="root")
+        user = models.User(email="sa@example.com", hashed_password=hash_password("root"), full_name="SA")
+        assoc = models.UserTenant(user_id=user.id, tenant_id=tenant.id, role_id=sa_role.id)
+        db.add_all([tenant, user, assoc])
+        db.commit()
+        db.refresh(tenant)
+        db.refresh(user)
+        return user, tenant
+
+
+def test_register_and_approve():
+    sa_user, tenant = setup_superadmin()
+    login = client.post("/auth/login", json={"email": sa_user.email, "password": "root", "tenant_id": str(tenant.id)})
+    assert login.status_code == 200
+    token = login.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    reg_data = {"email": "new@example.com", "password": "pass", "full_name": "New"}
+    r = client.post("/register", json=reg_data, params={"tenant_id": str(tenant.id)})
+    assert r.status_code == 201
+    new_id = r.json()["user_id"]
+
+    fail = client.post("/auth/login", json={"email": "new@example.com", "password": "pass", "tenant_id": str(tenant.id)})
+    assert fail.status_code == 401
+
+    pending = client.get("/superadmin/pending-users", headers=headers)
+    assert any(u["id"] == new_id for u in pending.json())
+
+    appr = client.post(f"/superadmin/pending-users/{new_id}/approve", headers=headers)
+    assert appr.status_code == 204
+
+    ok = client.post("/auth/login", json={"email": "new@example.com", "password": "pass", "tenant_id": str(tenant.id)})
+    assert ok.status_code == 200
+


### PR DESCRIPTION
## Apibendrinimas
- `User` modeliui pridėtas `is_active` laukas
- praplėstos CRUD funkcijos ir autentifikavimas, kad tik aktyvūs vartotojai galėtų prisijungti
- `main.py` pridėti endpointai registracijai, laukiančių vartotojų sąrašui bei patvirtinimui
- sukurti testai `test_registration.py`

## Testavimas
- `pytest -q` (tikėtini modulio importo klaidos dėl neiįdiegtų priklausomybių)


------
https://chatgpt.com/codex/tasks/task_e_686671cbbb9c8324bf1f1207d8fe2933