### PR TITLE
Tęsiamas perėjimas prie FastAPI

### DIFF
--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -491,3 +491,21 @@ def test_eu_countries(tmp_path):
     data = resp.json()["data"]
     assert any(c["code"] == "LT" for c in data)
 
+
+def test_active_users_csv(tmp_path):
+    client = create_client(tmp_path)
+    db_path = tmp_path / "app.db"
+    conn = sqlite3.connect(db_path)
+    c = conn.cursor()
+    c.execute(
+        "INSERT INTO users (username, password_hash, aktyvus) VALUES (?,?,1)",
+        ("x@a.com", auth_utils.hash_password("x")),
+    )
+    conn.commit()
+    conn.close()
+
+    resp = client.get("/api/aktyvus.csv")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/csv")
+    assert "username" in resp.text.splitlines()[0]
+

--- a/web_app/main.py
+++ b/web_app/main.py
@@ -1804,6 +1804,22 @@ def aktyvus_api(
     return {"data": data}
 
 
+@app.get("/api/aktyvus.csv")
+def aktyvus_csv(
+    db: tuple[sqlite3.Connection, sqlite3.Cursor] = Depends(get_db),
+    auth: None = Depends(require_roles(Role.ADMIN, Role.COMPANY_ADMIN)),
+):
+    """Aktyvių naudotojų sąrašas CSV formatu."""
+    conn, cursor = db
+    rows = cursor.execute(
+        "SELECT username, imone, last_login FROM users WHERE aktyvus=1 ORDER BY imone, username"
+    ).fetchall()
+    df = pd.DataFrame(rows, columns=["username", "imone", "last_login"])
+    csv_data = df.to_csv(index=False)
+    headers = {"Content-Disposition": "attachment; filename=aktyvus.csv"}
+    return Response(content=csv_data, media_type="text/csv", headers=headers)
+
+
 @app.get("/registracijos/{uid}/approve")
 def registracijos_approve(
     uid: int,


### PR DESCRIPTION
## Kas padaryta
1. `web_app/main.py` pridėjau naują `/api/aktyvus.csv` maršrutą. Jis leidžia atsisiųsti aktyvių naudotojų sąrašą CSV formatu.
2. Atnaujintas `tests/test_web_app.py` – pridėtas testas patikrinantis naujo CSV maršruto veikimą.

## Kas planuojama
1. Peržiūrėti likusius modulius ar dar yra neatitikimų tarp Streamlit ir FastAPI versijų.
2. Papildyti dokumentaciją apie pasikeitusias API galimybes.


------
https://chatgpt.com/codex/tasks/task_e_686674cb25908324885fcc28334ad64b