### PR TITLE
Tęsiama modulių perkėlimas į FastAPI

### DIFF
--- a/fastapi_app/app/main.py
+++ b/fastapi_app/app/main.py
@@ -1129,3 +1129,19 @@ def eu_countries_api():
     return {
         "data": [{"name": name, "code": code} for name, code in EU_COUNTRIES if name]
     }
+
+
+@app.get("/roles", response_model=list[schemas.Role])
+def read_roles(db: Session = Depends(auth.get_db)):
+    """Grąžina visų rolių sąrašą."""
+    return db.query(models.Role).order_by(models.Role.id).all()
+
+
+@app.get("/roles.csv")
+def read_roles_csv(db: Session = Depends(auth.get_db)):
+    """Rolių sąrašas CSV formatu."""
+    rows = db.query(models.Role).order_by(models.Role.id).all()
+    df = pd.DataFrame([{"id": r.id, "name": r.name} for r in rows])
+    csv_data = df.to_csv(index=False)
+    headers = {"Content-Disposition": "attachment; filename=roles.csv"}
+    return Response(content=csv_data, media_type="text/csv", headers=headers)

--- a/fastapi_app/tests/test_roles_api.py
+++ b/fastapi_app/tests/test_roles_api.py
@@ -1,0 +1,41 @@
+import os
+os.environ.setdefault("SECRET_KEY", "test-secret")
+from fastapi.testclient import TestClient
+from fastapi_app.app.main import app
+from fastapi_app.app.auth import get_db
+from fastapi_app.app.database import Base
+from fastapi_app.app import models
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+import pandas as pd
+
+SQLALCHEMY_DATABASE_URL = "sqlite://"
+engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base.metadata.create_all(bind=engine)
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+app.dependency_overrides[get_db] = override_get_db
+client = TestClient(app)
+
+
+def test_roles_list_and_csv():
+    with TestingSessionLocal() as db:
+        db.add_all([models.Role(name="USER"), models.Role(name="ADMIN")])
+        db.commit()
+
+    resp = client.get("/roles")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert any(r["name"] == "USER" for r in data)
+
+    resp_csv = client.get("/roles.csv")
+    assert resp_csv.status_code == 200
+    assert "name" in resp_csv.text.splitlines()[0]


### PR DESCRIPTION
## Aprašymas
- pridėtas rolių sąrašo API FastAPI aplikacijoje
- naujas `/roles.csv` CSV eksportas
- sukurti testai `test_roles_api.py`

## Testai
- `pytest -q` (nepavyko dėl trūkstamų priklausomybių)


------
https://chatgpt.com/codex/tasks/task_e_686677d2ee5c83248d65ea0be0936eb1