### PR TITLE
Perkelti CSV eksporto funkcijas į FastAPI

### DIFF
--- a/fastapi_app/app/main.py
+++ b/fastapi_app/app/main.py
@@ -764,6 +764,19 @@ def delete_trailer_spec(
     return Response(status_code=204)
 
 
+@app.get("/trailer-specs.csv")
+def trailer_specs_csv(
+    current_user=Depends(auth.get_current_user),
+    db: Session = Depends(auth.get_db),
+):
+    """Priekabų specifikacijų sąrašas CSV formatu."""
+    rows = crud.get_trailer_specs(db)
+    df = pd.DataFrame([schemas.TrailerSpec.from_orm(r).dict() for r in rows])
+    csv_data = df.to_csv(index=False)
+    headers = {"Content-Disposition": "attachment; filename=trailer-specs.csv"}
+    return Response(content=csv_data, media_type="text/csv", headers=headers)
+
+
 @app.post("/trailer-types", response_model=schemas.TrailerType)
 def create_trailer_type(
     tt: schemas.TrailerTypeCreate,
@@ -804,6 +817,19 @@ def delete_trailer_type(
     if not ok:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
     return Response(status_code=204)
+
+
+@app.get("/trailer-types.csv")
+def trailer_types_csv(
+    current_user=Depends(auth.get_current_user),
+    db: Session = Depends(auth.get_db),
+):
+    """Priekabų tipų sąrašas CSV formatu."""
+    rows = crud.get_trailer_types(db)
+    df = pd.DataFrame([schemas.TrailerType.from_orm(r).dict() for r in rows])
+    csv_data = df.to_csv(index=False)
+    headers = {"Content-Disposition": "attachment; filename=trailer-types.csv"}
+    return Response(content=csv_data, media_type="text/csv", headers=headers)
 
 
 @app.get("/{tenant_id}/default-trailer-types", response_model=list[str])
@@ -915,6 +941,22 @@ def delete_client_api(
     return Response(status_code=204)
 
 
+@app.get("/{tenant_id}/clients.csv")
+def clients_csv(
+    tenant_id: str,
+    current_user=Depends(auth.get_current_user),
+    db: Session = Depends(auth.get_db),
+):
+    """Klientų sąrašas CSV formatu."""
+    if str(current_user.current_tenant_id) != tenant_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
+    rows = crud.get_clients(db, UUID(tenant_id))
+    df = pd.DataFrame([schemas.Client.from_orm(r).dict() for r in rows])
+    csv_data = df.to_csv(index=False)
+    headers = {"Content-Disposition": "attachment; filename=clients.csv"}
+    return Response(content=csv_data, media_type="text/csv", headers=headers)
+
+
 @app.post("/{tenant_id}/groups", response_model=schemas.Group)
 def create_group_api(
     tenant_id: str,
@@ -998,6 +1040,22 @@ def delete_group_api(
         ),
     )
     return Response(status_code=204)
+
+
+@app.get("/{tenant_id}/groups.csv")
+def groups_csv(
+    tenant_id: str,
+    current_user=Depends(auth.get_current_user),
+    db: Session = Depends(auth.get_db),
+):
+    """Grupių sąrašas CSV formatu."""
+    if str(current_user.current_tenant_id) != tenant_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
+    rows = crud.get_groups(db, UUID(tenant_id))
+    df = pd.DataFrame([schemas.Group.from_orm(r).dict() for r in rows])
+    csv_data = df.to_csv(index=False)
+    headers = {"Content-Disposition": "attachment; filename=groups.csv"}
+    return Response(content=csv_data, media_type="text/csv", headers=headers)
 
 
 @app.post("/{tenant_id}/employees", response_model=schemas.Employee)
@@ -1085,6 +1143,22 @@ def delete_employee_api(
     return Response(status_code=204)
 
 
+@app.get("/{tenant_id}/employees.csv")
+def employees_csv(
+    tenant_id: str,
+    current_user=Depends(auth.get_current_user),
+    db: Session = Depends(auth.get_db),
+):
+    """Darbuotojų sąrašas CSV formatu."""
+    if str(current_user.current_tenant_id) != tenant_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
+    rows = crud.get_employees(db, UUID(tenant_id))
+    df = pd.DataFrame([schemas.Employee.from_orm(r).dict() for r in rows])
+    csv_data = df.to_csv(index=False)
+    headers = {"Content-Disposition": "attachment; filename=employees.csv"}
+    return Response(content=csv_data, media_type="text/csv", headers=headers)
+
+
 @app.post("/{tenant_id}/updates", response_model=schemas.Update)
 def create_update_api(
     tenant_id: str,
@@ -1168,6 +1242,22 @@ def delete_update_api(
         ),
     )
     return Response(status_code=204)
+
+
+@app.get("/{tenant_id}/updates.csv")
+def updates_csv(
+    tenant_id: str,
+    current_user=Depends(auth.get_current_user),
+    db: Session = Depends(auth.get_db),
+):
+    """Vilkikų darbo laiko įrašai CSV formatu."""
+    if str(current_user.current_tenant_id) != tenant_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
+    rows = crud.get_updates(db, UUID(tenant_id))
+    df = pd.DataFrame([schemas.Update.from_orm(r).dict() for r in rows])
+    csv_data = df.to_csv(index=False)
+    headers = {"Content-Disposition": "attachment; filename=updates.csv"}
+    return Response(content=csv_data, media_type="text/csv", headers=headers)
 
 
 @app.post("/audit", response_model=schemas.AuditLog)

--- a/fastapi_app/tests/test_csv_endpoints.py
+++ b/fastapi_app/tests/test_csv_endpoints.py
@@ -79,6 +79,19 @@ def test_csv_exports():
         headers=headers,
     )
     client.post(f"/{tenant.id}/trailers", json={"numeris": "TR123"}, headers=headers)
+    client.post(f"/{tenant.id}/clients", json={"pavadinimas": "ACME"}, headers=headers)
+    client.post(f"/{tenant.id}/groups", json={"numeris": "G1"}, headers=headers)
+    client.post(f"/{tenant.id}/employees", json={"vardas": "E", "pavarde": "V"}, headers=headers)
+    client.post(
+        f"/{tenant.id}/updates",
+        json={"vilkiko_numeris": "AAA111", "data": "2023-01-01"},
+        headers=headers,
+    )
+
+    with TestingSessionLocal() as db:
+        db.add(models.TrailerSpec(tipas="Mega"))
+        db.add(models.TrailerType(name="Type1"))
+        db.commit()
 
     r1 = client.get(f"/{tenant.id}/shipments.csv", headers=headers)
     assert r1.status_code == 200
@@ -95,3 +108,27 @@ def test_csv_exports():
     r4 = client.get(f"/{tenant.id}/trailers.csv", headers=headers)
     assert r4.status_code == 200
     assert "numeris" in r4.text.splitlines()[0]
+
+    r5 = client.get(f"/{tenant.id}/clients.csv", headers=headers)
+    assert r5.status_code == 200
+    assert "pavadinimas" in r5.text.splitlines()[0]
+
+    r6 = client.get(f"/{tenant.id}/groups.csv", headers=headers)
+    assert r6.status_code == 200
+    assert "numeris" in r6.text.splitlines()[0]
+
+    r7 = client.get(f"/{tenant.id}/employees.csv", headers=headers)
+    assert r7.status_code == 200
+    assert "vardas" in r7.text.splitlines()[0]
+
+    r8 = client.get(f"/{tenant.id}/updates.csv", headers=headers)
+    assert r8.status_code == 200
+    assert "vilkiko_numeris" in r8.text.splitlines()[0]
+
+    r9 = client.get("/trailer-specs.csv", headers=headers)
+    assert r9.status_code == 200
+    assert "tipas" in r9.text.splitlines()[0]
+
+    r10 = client.get("/trailer-types.csv", headers=headers)
+    assert r10.status_code == 200
+    assert "name" in r10.text.splitlines()[0]


### PR DESCRIPTION
## Apžvalga
- pridėti kliento, grupių, darbuotojų, atnaujinimų, priekabų specifikacijų ir tipų CSV eksportą FastAPI aplikacijoje
- atnaujinti testus, kad tikrintų naujus endpointus

## Pastabos
- testų paleisti nepavyko dėl trūkstamų `fastapi` priklausomybių

------
https://chatgpt.com/codex/tasks/task_e_68667ee5bef08324a1854a978776f6b1