### PR TITLE
Pridėti CSV eksportą numatytiems priekabų tipams

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains a Streamlit based application for logistics companies. The app manages shipments, vehicles and staff information in a single dashboard and stores all data in a local SQLite database.
 
-Besides the Streamlit UI, the repository now provides an alternative FastAPI based web interface located in the `web_app` directory. This interface relies on DataTables for an Excel-style look and can be started locally without Streamlit. Initially it only supported shipment management but now also includes trucks, trailers, employees, groups, clients, drivers, trailer type management and an audit log section and a simple login/registration system. Naujausioje versijoje taip pat galima atsisiųsti darbuotojų, grupių, klientų, vairuotojų bei priekabų specifikacijų sąrašus CSV formatu.
+Besides the Streamlit UI, the repository now provides an alternative FastAPI based web interface located in the `web_app` directory. This interface relies on DataTables for an Excel-style look and can be started locally without Streamlit. Initially it only supported shipment management but now also includes trucks, trailers, employees, groups, clients, drivers, trailer type management and an audit log section and a simple login/registration system. Naujausioje versijoje taip pat galima atsisiųsti darbuotojų, grupių, klientų, vairuotojų bei priekabų specifikacijų bei numatytų priekabų tipų sąrašus CSV formatu.
 
 ## Setup
 

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -305,6 +305,11 @@ def test_settings_defaults(tmp_path):
     data = resp.json()["data"]
     assert data == ["Van", "Box"]
 
+    resp = client.get("/api/default-trailer-types.csv?imone=A")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/csv")
+    assert "reiksme" in resp.text.splitlines()[0]
+
 
 def test_access_restrictions(tmp_path):
     client = create_client(tmp_path, do_login=False)

--- a/web_app/main.py
+++ b/web_app/main.py
@@ -1736,6 +1736,25 @@ def default_trailer_types_api(
     return {"data": [r[0] for r in rows]}
 
 
+@app.get("/api/default-trailer-types.csv")
+def default_trailer_types_csv(
+    imone: str = "",
+    db: tuple[sqlite3.Connection, sqlite3.Cursor] = Depends(get_db),
+    auth: None = Depends(require_roles(Role.ADMIN)),
+):
+    """Grąžina numatytuosius priekabų tipus CSV formatu."""
+    conn, cursor = db
+    cursor.execute(
+        "SELECT reiksme FROM company_default_trailers WHERE imone=? ORDER BY priority",
+        (imone,),
+    )
+    rows = cursor.fetchall()
+    df = pd.DataFrame(rows, columns=["reiksme"])
+    csv_data = df.to_csv(index=False)
+    headers = {"Content-Disposition": "attachment; filename=default-trailer-types.csv"}
+    return Response(content=csv_data, media_type="text/csv", headers=headers)
+
+
 @app.post("/settings/save")
 async def settings_save(
     request: Request,


### PR DESCRIPTION
## Summary
- web_app: pridėjau `/api/default-trailer-types.csv` galimybę
- atnaujinau README ir testus

## Testing
- `pytest -q` *(failed: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6866817b45248324906fcfbc22ff51fc