### PR TITLE
Pridėti grupių regionų API

### DIFF
--- a/fastapi_app/app/crud.py
+++ b/fastapi_app/app/crud.py
@@ -599,3 +599,45 @@ def get_updates(db: Session, tenant_id: UUID) -> list[models.UpdateEntry]:
         .all()
     )
 
+
+def create_group_region(
+    db: Session, tenant_id: UUID, group_id: int, region_code: str
+) -> models.GroupRegion:
+    region = models.GroupRegion(
+        tenant_id=tenant_id, group_id=group_id, region_code=region_code
+    )
+    db.add(region)
+    db.commit()
+    db.refresh(region)
+    return region
+
+
+def get_group_regions(
+    db: Session, tenant_id: UUID, group_id: int
+) -> list[models.GroupRegion]:
+    return (
+        db.query(models.GroupRegion)
+        .filter(
+            models.GroupRegion.tenant_id == tenant_id,
+            models.GroupRegion.group_id == group_id,
+        )
+        .order_by(models.GroupRegion.id)
+        .all()
+    )
+
+
+def delete_group_region(db: Session, tenant_id: UUID, region_id: int) -> bool:
+    region = (
+        db.query(models.GroupRegion)
+        .filter(
+            models.GroupRegion.id == region_id,
+            models.GroupRegion.tenant_id == tenant_id,
+        )
+        .first()
+    )
+    if not region:
+        return False
+    db.delete(region)
+    db.commit()
+    return True
+

--- a/fastapi_app/app/main.py
+++ b/fastapi_app/app/main.py
@@ -1058,6 +1058,47 @@ def groups_csv(
     return Response(content=csv_data, media_type="text/csv", headers=headers)
 
 
+@app.post("/{tenant_id}/groups/{group_id}/regions", response_model=schemas.GroupRegion)
+def add_group_region_api(
+    tenant_id: str,
+    group_id: int,
+    data: schemas.GroupRegionCreate,
+    current_user=Depends(auth.get_current_user),
+    db: Session = Depends(auth.get_db),
+):
+    if str(current_user.current_tenant_id) != tenant_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
+    region = crud.create_group_region(db, UUID(tenant_id), group_id, data.region_code)
+    return region
+
+
+@app.get("/{tenant_id}/groups/{group_id}/regions", response_model=list[schemas.GroupRegion])
+def list_group_regions_api(
+    tenant_id: str,
+    group_id: int,
+    current_user=Depends(auth.get_current_user),
+    db: Session = Depends(auth.get_db),
+):
+    if str(current_user.current_tenant_id) != tenant_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
+    return crud.get_group_regions(db, UUID(tenant_id), group_id)
+
+
+@app.delete("/{tenant_id}/group-regions/{region_id}", status_code=204)
+def delete_group_region_api(
+    tenant_id: str,
+    region_id: int,
+    current_user=Depends(auth.get_current_user),
+    db: Session = Depends(auth.get_db),
+):
+    if str(current_user.current_tenant_id) != tenant_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
+    ok = crud.delete_group_region(db, UUID(tenant_id), region_id)
+    if not ok:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    return Response(status_code=204)
+
+
 @app.post("/{tenant_id}/employees", response_model=schemas.Employee)
 def create_employee_api(
     tenant_id: str,

--- a/fastapi_app/app/models.py
+++ b/fastapi_app/app/models.py
@@ -196,6 +196,20 @@ class Group(Base):
     tenant = relationship("Tenant")
 
 
+class GroupRegion(Base):
+    """Regionai priskirti ekspedicijos ar transporto grupei"""
+
+    __tablename__ = "group_regions"
+
+    id = Column(Integer, primary_key=True)
+    tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenants.id"), nullable=False)
+    group_id = Column(Integer, ForeignKey("groups.id"), nullable=False)
+    region_code = Column(String, nullable=False)
+
+    tenant = relationship("Tenant")
+    group = relationship("Group")
+
+
 class Employee(Base):
     """Darbuotojo įrašas"""
 

--- a/fastapi_app/app/schemas.py
+++ b/fastapi_app/app/schemas.py
@@ -257,6 +257,23 @@ class Group(GroupBase):
         orm_mode = True
 
 
+class GroupRegionBase(BaseModel):
+    region_code: str
+
+
+class GroupRegionCreate(GroupRegionBase):
+    pass
+
+
+class GroupRegion(GroupRegionBase):
+    id: int
+    group_id: int
+    tenant_id: UUID
+
+    class Config:
+        orm_mode = True
+
+
 class EmployeeBase(BaseModel):
     vardas: str
     pavarde: str

--- a/fastapi_app/tests/test_group_regions.py
+++ b/fastapi_app/tests/test_group_regions.py
@@ -1,0 +1,69 @@
+import os
+os.environ.setdefault("SECRET_KEY", "test-secret")
+from fastapi.testclient import TestClient
+from fastapi_app.app.main import app
+from fastapi_app.app.auth import get_db, hash_password
+from fastapi_app.app.database import Base
+from fastapi_app.app import models
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+SQLALCHEMY_DATABASE_URL = "sqlite://"
+engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base.metadata.create_all(bind=engine)
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+app.dependency_overrides[get_db] = override_get_db
+client = TestClient(app)
+
+
+def setup_user():
+    with TestingSessionLocal() as db:
+        role = db.query(models.Role).filter(models.Role.name == "USER").first()
+        if not role:
+            role = models.Role(name="USER")
+            db.add(role)
+            db.commit()
+            db.refresh(role)
+        tenant = models.Tenant(name="t_gr")
+        user = models.User(email="gr@example.com", hashed_password=hash_password("pass"), full_name="GroupRegion")
+        assoc = models.UserTenant(user_id=user.id, tenant_id=tenant.id, role_id=role.id)
+        db.add_all([tenant, user, assoc])
+        db.commit()
+        db.refresh(user)
+        db.refresh(tenant)
+        return user, tenant
+
+
+def test_group_region_crud():
+    user, tenant = setup_user()
+    resp = client.post("/auth/login", json={"email": user.email, "password": "pass", "tenant_id": str(tenant.id)})
+    token = resp.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    data = {"numeris": "TR1"}
+    r = client.post(f"/{tenant.id}/groups", json=data, headers=headers)
+    gid = r.json()["id"]
+
+    reg_data = {"region_code": "LT01"}
+    r2 = client.post(f"/{tenant.id}/groups/{gid}/regions", json=reg_data, headers=headers)
+    assert r2.status_code == 200
+    rid = r2.json()["id"]
+
+    r3 = client.get(f"/{tenant.id}/groups/{gid}/regions", headers=headers)
+    assert any(reg["id"] == rid for reg in r3.json())
+
+    r4 = client.delete(f"/{tenant.id}/group-regions/{rid}", headers=headers)
+    assert r4.status_code == 204
+    r5 = client.get(f"/{tenant.id}/groups/{gid}/regions", headers=headers)
+    assert r5.json() == []


### PR DESCRIPTION
## Kas padaryta
- Sukurta `GroupRegion` SQLAlchemy klasė atvaizduojanti grupių ir regionų ryšį
- Į `schemas.py` pridėti `GroupRegion*` modeliai
- `crud.py` pridėtos funkcijos regionų kūrimui, gavimui ir šalinimui
- `main.py` sukurtos naujos API nuorodos regionams pridėti, gauti ir trinti
- Parašytas testas `test_group_regions.py`

## Kas toliau
- Pridėti planavimo funkcionalumą FastAPI dalyje naudojant šiuos regionų duomenis
- Atnaujinti dokumentaciją ir integruoti naujas funkcijas į likusius modulius

------
https://chatgpt.com/codex/tasks/task_e_6866a150f32083249efa388ef987bf0f