### PR TITLE
Tęsti perkėlimą į FastAPI – pridėtas CSV grupių regionams

### DIFF
--- a/fastapi_app/app/crud.py
+++ b/fastapi_app/app/crud.py
@@ -626,6 +626,16 @@ def get_group_regions(
     )
 
 
+def get_all_group_regions(db: Session, tenant_id: UUID) -> list[models.GroupRegion]:
+    """Gauti visus įmonės priskirtus regionus."""
+    return (
+        db.query(models.GroupRegion)
+        .filter(models.GroupRegion.tenant_id == tenant_id)
+        .order_by(models.GroupRegion.id)
+        .all()
+    )
+
+
 def delete_group_region(db: Session, tenant_id: UUID, region_id: int) -> bool:
     region = (
         db.query(models.GroupRegion)

--- a/fastapi_app/tests/test_group_regions.py
+++ b/fastapi_app/tests/test_group_regions.py
@@ -67,3 +67,26 @@ def test_group_region_crud():
     assert r4.status_code == 204
     r5 = client.get(f"/{tenant.id}/groups/{gid}/regions", headers=headers)
     assert r5.json() == []
+
+
+def test_group_regions_csv():
+    user, tenant = setup_user()
+    resp = client.post(
+        "/auth/login",
+        json={"email": user.email, "password": "pass", "tenant_id": str(tenant.id)},
+    )
+    token = resp.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    grp = client.post(f"/{tenant.id}/groups", json={"numeris": "G1"}, headers=headers)
+    gid = grp.json()["id"]
+    client.post(
+        f"/{tenant.id}/groups/{gid}/regions",
+        json={"region_code": "LT01"},
+        headers=headers,
+    )
+
+    r = client.get(f"/{tenant.id}/group-regions.csv", headers=headers)
+    assert r.status_code == 200
+    assert "region_code" in r.text.splitlines()[0]
+    assert "LT01" in r.text


### PR DESCRIPTION
## Apibendrinimas
- CRUD moduliuose įdiegta `get_all_group_regions` funkcija
- `main.py` pridėtas `/tenant_id/group-regions.csv` maršrutas
- atnaujinti testai, kad tikrintų naujo CSV eksporto veikimą

## Tolimesni planai
1. Išplėsti FastAPI modelius, kad atkartotų visus Streamlit laukus
2. Sukurti planavimo API ir papildomus testus
3. Tobulinti naudotojų teisių bei registracijos valdymą


------
https://chatgpt.com/codex/tasks/task_e_6866a38c8f248324adc99ea576178000