### PR TITLE
Tęsiama perkelimas į FastAPI

### DIFF
--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -467,6 +467,33 @@ def test_updates_basic(tmp_path):
     assert "vilkiko_numeris" in resp.text.splitlines()[0]
 
 
+def test_updates_range(tmp_path):
+    client = create_client(tmp_path)
+    form = {
+        "uid": "0",
+        "vilkiko_numeris": "AAA111",
+        "data": "2023-01-01",
+        "darbo_laikas": "8",
+        "likes_laikas": "4",
+        "sa": "SA",
+        "pakrovimo_statusas": "Pakrauta",
+        "pakrovimo_laikas": "10:00",
+        "pakrovimo_data": "2023-01-01",
+        "iskrovimo_statusas": "",
+        "iskrovimo_laikas": "",
+        "iskrovimo_data": "",
+        "komentaras": "t",
+    }
+    client.post("/updates/save", data=form, allow_redirects=False)
+    resp = client.get(
+        "/api/updates-range?start=2023-01-01&end=2023-01-02&vilkikas=AAA111"
+    )
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert len(data) == 1
+    assert data[0]["vilkiko_numeris"] == "AAA111"
+
+
 def test_klientai_limits(tmp_path):
     client = create_client(tmp_path)
     form = {

--- a/web_app/main.py
+++ b/web_app/main.py
@@ -2525,6 +2525,27 @@ def updates_csv(db: tuple[sqlite3.Connection, sqlite3.Cursor] = Depends(get_db))
     return Response(content=csv_data, media_type="text/csv", headers=headers)
 
 
+@app.get("/api/updates-range")
+def updates_range(
+    start: str,
+    end: str,
+    vilkikas: str | None = None,
+    db: tuple[sqlite3.Connection, sqlite3.Cursor] = Depends(get_db),
+):
+    """Grąžina darbo laiko įrašus pasirinktam intervalui."""
+    conn, cursor = db
+    query = "SELECT * FROM vilkiku_darbo_laikai WHERE date(data) BETWEEN ? AND ?"
+    params: list[str] = [start, end]
+    if vilkikas:
+        query += " AND vilkiko_numeris=?"
+        params.append(vilkikas)
+    cursor.execute(query, params)
+    rows = cursor.fetchall()
+    columns = [col[1] for col in cursor.execute("PRAGMA table_info(vilkiku_darbo_laikai)")]
+    data = [dict(zip(columns, row)) for row in rows]
+    return {"data": data}
+
+
 # ---- Authentication ----
 
 


### PR DESCRIPTION
## Atlikta
- Sukurtas naujas `/api/updates-range` maršrutas, leidžiantis filtruoti darbo laiko įrašus pagal datų intervalą ir vilkiką
- Pridėtas vienetinis testas `test_updates_range`

## Planai
- Toliau plėsti FastAPI galimybes pagal likusius Streamlit modulius


------
https://chatgpt.com/codex/tasks/task_e_6866aed28aa48324afe33efc15bbf8d8