### PR TITLE
Tęsiamas FastAPI funkcionalumų perkėlimas

### DIFF
--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -714,3 +714,18 @@ def test_trailer_swap(tmp_path):
     data = {row["numeris"]: row for row in resp.json()["data"]}
     assert data["AAA111"]["priekaba"] == ""
     assert data["BBB222"]["priekaba"] == "TR1"
+
+
+def test_trailer_types_delete(tmp_path):
+    client = create_client(tmp_path)
+    form = {"tid": "0", "reiksme": "Specialus"}
+    resp = client.post("/trailer-types/save", data=form, allow_redirects=False)
+    assert resp.status_code == 303
+    resp = client.get("/api/trailer-types")
+    data = resp.json()["data"]
+    assert len(data) == 1
+    tid = data[0]["id"]
+    resp = client.get(f"/trailer-types/{tid}/delete", allow_redirects=False)
+    assert resp.status_code == 303
+    resp = client.get("/api/trailer-types")
+    assert resp.json() == {"data": []}


### PR DESCRIPTION
## Atlikta
1. `web_app/main.py` pridėtas maršrutas `trailer-types/{tid}/delete`, skirtas priekabos tipo šalinimui. Jis tikrina vartotojo rolę ir įrašo veiksmą į auditą.
2. `tests/test_web_app.py` įtrauktas naujas testas `test_trailer_types_delete`, kuris patikrina ištrynimo veiksmą per API.

## Testai
- `pytest -q` – nepavyko įdiegti priklausomybių dėl užblokuoto interneto, todėl testai nesuveikė.

------
https://chatgpt.com/codex/tasks/task_e_6866b8c95f2483248055c0e74ba35bb9