### PR TITLE
Improve updates module

### DIFF
--- a/web_app/templates/updates_form.html
+++ b/web_app/templates/updates_form.html
@@ -1,10 +1,11 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2>{% if data.id %}Redaguoti įrašą{% else %}Naujas įrašas{% endif %}</h2>
+<h2>{% if data.id %}Redaguoti įrašą{% else %}Atnaujinti krovinį{% endif %}</h2>
 <form method="post" action="/updates/save">
     <input type="hidden" name="uid" value="{{ data.id or 0 }}">
-    <label>Vilkikas: <input type="text" name="vilkiko_numeris" value="{{ data.vilkiko_numeris or '' }}"></label><br>
-    <label>Data: <input type="date" name="data" value="{{ data.data or '' }}"></label><br>
+    <input type="hidden" name="vilkiko_numeris" value="{{ data.vilkiko_numeris }}">
+    <input type="hidden" name="data" value="{{ data.data }}">
+    <p>Vilkikas: <b>{{ data.vilkiko_numeris }}</b> | Data: <b>{{ data.data }}</b></p>
     <label>Darbo laikas: <input type="number" name="darbo_laikas" value="{{ data.darbo_laikas or 0 }}"></label><br>
     <label>Likusios valandos: <input type="number" name="likes_laikas" value="{{ data.likes_laikas or 0 }}"></label><br>
     <label>SA: <input type="text" name="sa" value="{{ data.sa or '' }}"></label><br>

--- a/web_app/templates/updates_list.html
+++ b/web_app/templates/updates_list.html
@@ -1,7 +1,13 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Padėties atnaujinimai</h2>
-<a href="/updates/add">Pridėti naują</a>
+<label>Transporto vadybininkas:
+    <select id="manager-select">
+        {% for m in managers %}
+            <option value="{{ m }}">{{ m }}</option>
+        {% endfor %}
+    </select>
+</label>
 <table id="updates-table" class="display" style="width:100%">
     <thead>
         <tr>
@@ -24,28 +30,30 @@
     </thead>
 </table>
 <script>
-$(document).ready(function() {
+function loadTable(mgr){
     $('#updates-table').DataTable({
-        ajax: '/api/updates',
+        destroy: true,
+        ajax: '/api/shipments?manager=' + encodeURIComponent(mgr),
         columns: [
             { data: 'id' },
-            { data: 'vilkiko_numeris' },
-            { data: 'data' },
-            { data: 'sa' },
-            { data: 'darbo_laikas' },
-            { data: 'likes_laikas' },
+            { data: 'vilkikas' },
             { data: 'pakrovimo_data' },
-            { data: 'pakrovimo_laikas', render: function(d){return formatTime(d);} },
-            { data: 'pakrovimo_statusas' },
             { data: 'iskrovimo_data' },
-            { data: 'iskrovimo_laikas', render: function(d){return formatTime(d);} },
+            { data: 'pakrovimo_statusas' },
             { data: 'iskrovimo_statusas' },
-            { data: 'komentaras' },
             { data: 'created_at', render: function(d){return relativeTime(d);} },
-            { data: null, render: function(data, type, row) {
-                return '<a href="/updates/' + row.id + '/edit">Edit</a>';
+            { data: null, render: function(data, type, row){
+                return '<a href="/updates/ship/' + row.id + '">Edit</a>';
             }}
         ]
+    });
+}
+
+$(document).ready(function(){
+    var mgr = $('#manager-select').val();
+    loadTable(mgr);
+    $('#manager-select').on('change', function(){
+        loadTable(this.value);
     });
 });
 


### PR DESCRIPTION
## Summary
- integrate updates with shipments
- list managers to filter updates
- allow editing of shipment updates via new `/updates/ship/{id}` route
- show manager selector and dynamic table in updates list
- restrict truck/date fields when editing

## Testing
- `pytest -q` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_6866d57820308324b0d5430d55e68d40