### PR TITLE
Fix employee add form

### DIFF
--- a/web_app/main.py
+++ b/web_app/main.py
@@ -1432,11 +1432,12 @@ def darbuotojai_add_form(
 ):
     conn, cursor = db
     grupes = [r[0] for r in cursor.execute("SELECT numeris FROM grupes").fetchall()]
+    data = {"imone": request.session.get("imone", "")}
     return templates.TemplateResponse(
         "darbuotojai_form.html",
         {
             "request": request,
-            "data": {},
+            "data": data,
             "roles": EMPLOYEE_ROLES,
             "grupes": grupes,
         },


### PR DESCRIPTION
## Summary
- preserve `imone` when adding new employees so list shows saved employee

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6866dc14fc3c83249fcfa08e8a487d1a