### PR TITLE
Fix groups table schema

### DIFF
--- a/modules/grupes.py
+++ b/modules/grupes.py
@@ -10,15 +10,18 @@ from .audit import log_action
 def show(conn, c):
 
     # 1) Užtikrinti, kad egzistuotų lentelė „grupes“
-    c.execute("""
+    c.execute(
+        """
         CREATE TABLE IF NOT EXISTS grupes (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
-            numeris TEXT UNIQUE,
+            numeris TEXT,
             pavadinimas TEXT,
             aprasymas TEXT,
-            imone TEXT
+            imone TEXT,
+            UNIQUE (numeris, imone)
         )
-    """)
+        """
+    )
     c.execute("PRAGMA table_info(grupes)")
     cols = [r[1] for r in c.fetchall()]
     if 'imone' not in cols:


### PR DESCRIPTION
## Summary
- fix groups table creation to allow duplicates per company

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6866def197e08324bbe18e8082b628ca