### PR TITLE
Portavimo tęsinys į FastAPI

### DIFF
--- a/web_app/auth/__init__.py
+++ b/web_app/auth/__init__.py
@@ -123,4 +123,16 @@ def register_submit(
     )
 
 
+@router.get("/api/me")
+def current_user(request: Request):
+    """Grąžina prisijungusio vartotojo informaciją."""
+    if not ensure_logged_in(request):
+        raise HTTPException(status_code=401, detail="Nepatvirtintas vartotojas")
+    return {
+        "username": request.session.get("username"),
+        "imone": request.session.get("imone"),
+        "roles": request.session.get("roles", []),
+    }
+
+
 templates = Jinja2Templates(directory="web_app/templates")


### PR DESCRIPTION
## Summary
- pridėtas `/api/me` kelias, grąžinantis prisijungusio vartotojo duomenis

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686761d681a48324a696b00eb84b85a2