### PR TITLE
Pridėtas pagrindinis maršrutas FastAPI sąsajoje

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -8,6 +8,7 @@
 4. Sukurti API maršrutai duomenų eksportui į CSV formatą.
 5. Sukurta pagrindinė vartotojų administravimo funkcija (registracijų tvirtinimas ir aktyvių vartotojų sąrašas).
 6. Parengti testai FastAPI versijai (`tests/` ir `fastapi_app/tests/`).
+7. Pridėtas pagrindinis (`/`) maršrutas FastAPI sąsajoje.
 
 ## Numatomos užduotys
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ See [MIGRATION.md](MIGRATION.md) for a short summary of the migration progress.
    uvicorn web_app.main:app --reload
    ```
    This starts a local server on http://127.0.0.1:8000 without Streamlit.
+   After login the home page is available at `http://127.0.0.1:8000/`.
 
    The web application can also be executed directly as a module:
    ```bash

--- a/web_app/routers/__init__.py
+++ b/web_app/routers/__init__.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter
 
+from .home import router as home_router
 from .kroviniai import router as kroviniai_router
 from .planavimas import router as planavimas_router
 from .vilkikai import router as vilkikai_router
@@ -22,6 +23,7 @@ from .roles import router as roles_router
 
 router = APIRouter()
 for r in [
+    home_router,
     kroviniai_router,
     planavimas_router,
     vilkikai_router,

--- a/web_app/routers/home.py
+++ b/web_app/routers/home.py
@@ -1,0 +1,11 @@
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+router = APIRouter()
+templates = Jinja2Templates(directory="web_app/templates")
+
+@router.get("/", response_class=HTMLResponse)
+def index(request: Request):
+    """Pagrindinis puslapis po prisijungimo."""
+    return templates.TemplateResponse("index.html", {"request": request})


### PR DESCRIPTION
## Summary
- pridėtas `home.py` maršrutas grąžinantis `index.html`
- `router/__init__.py` papildytas `home_router`
- README papildyta nuoroda į pagrindinį puslapį
- MIGRATION.md pažymėtas dar vienas įgyvendintas žingsnis

## Testing
- `pytest -q` *(failed: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68676c569fd88324a6c00b15e12da8c0