### PR TITLE
Apply header macro across templates

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -12,11 +12,11 @@
 8. Sukurtas atskiras "trailer-swap" modulis priekabų priskyrimui vilkikams.
 9. "user_admin.py" funkcionalumas perkeltas į `registracijos` maršrutą.
 10. Sukurtas bendras Jinja makro "header_with_add" antraštėms su "pridėti" nuoroda.
+11. "header_with_add" makro pritaikytas visuose šablonuose.
 
 ## Numatomos užduotys
 
 1. Toliau tobulinti šablonus, kad vaizdas atitiktų Streamlit versiją.
 2. Perkelti likusius pagalbinius metodus iš `modules/utils.py`, jei jie dar naudojami.
 3. Sulyginti visų formų validaciją tarp Streamlit ir FastAPI versijų.
-4. Pritaikyti naująjį "header_with_add" makro visuose šablonuose.
 

--- a/web_app/templates/audit_list.html
+++ b/web_app/templates/audit_list.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
+{% from 'macros.html' import header_with_add %}
 {% block content %}
-<h2>Audit log</h2>
+{{ header_with_add('Audit log') }}
 <label>Naudotojas:
     <select id="user-filter">
         <option value="">Visi</option>

--- a/web_app/templates/darbuotojai_form.html
+++ b/web_app/templates/darbuotojai_form.html
@@ -1,6 +1,8 @@
 {% extends 'base.html' %}
+{% from 'macros.html' import header_with_add %}
 {% block content %}
-<h2>{% if data.id %}Redaguoti darbuotoją{% else %}Naujas darbuotojas{% endif %}</h2>
+{% set form_title = 'Redaguoti darbuotoją' if data.id else 'Naujas darbuotojas' %}
+{{ header_with_add(form_title) }}
 <form method="post" action="/darbuotojai/save">
     <input type="hidden" name="did" value="{{ data.id or 0 }}">
     <input type="hidden" name="imone" value="{{ data.imone or '' }}">

--- a/web_app/templates/grupes_form.html
+++ b/web_app/templates/grupes_form.html
@@ -1,6 +1,8 @@
 {% extends 'base.html' %}
+{% from 'macros.html' import header_with_add %}
 {% block content %}
-<h2>{% if data.id %}Redaguoti grupę{% else %}Nauja grupė{% endif %}</h2>
+{% set form_title = 'Redaguoti grupę' if data.id else 'Nauja grupė' %}
+{{ header_with_add(form_title) }}
 <form method="post" action="/grupes/save">
     <input type="hidden" name="gid" value="{{ data.id or 0 }}">
     <div class="form-grid">

--- a/web_app/templates/index.html
+++ b/web_app/templates/index.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
+{% from 'macros.html' import header_with_add %}
 {% block content %}
-<h2>Sveiki atvykę</h2>
+{{ header_with_add('Sveiki atvykę') }}
 <p>Papildoma sąsaja be Streamlit.</p>
 {% endblock %}

--- a/web_app/templates/klientai_form.html
+++ b/web_app/templates/klientai_form.html
@@ -1,6 +1,8 @@
 {% extends 'base.html' %}
+{% from 'macros.html' import header_with_add %}
 {% block content %}
-<h2>{% if data.id %}Redaguoti klientą{% else %}Naujas klientas{% endif %}</h2>
+{% set form_title = 'Redaguoti klientą' if data.id else 'Naujas klientas' %}
+{{ header_with_add(form_title) }}
 <form method="post" action="/klientai/save">
     <input type="hidden" name="cid" value="{{ data.id or 0 }}">
     <input type="hidden" name="imone" value="{{ data.imone or '' }}">

--- a/web_app/templates/kroviniai_form.html
+++ b/web_app/templates/kroviniai_form.html
@@ -1,6 +1,8 @@
 {% extends 'base.html' %}
+{% from 'macros.html' import header_with_add %}
 {% block content %}
-<h2>{% if data.id %}Redaguoti krovinį{% else %}Naujas krovinys{% endif %}</h2>
+{% set form_title = 'Redaguoti krovinį' if data.id else 'Naujas krovinys' %}
+{{ header_with_add(form_title) }}
 <form method="post" action="/kroviniai/save">
     <input type="hidden" name="cid" value="{{ data.id or 0 }}">
     <input type="hidden" name="imone" value="{{ imone }}">

--- a/web_app/templates/login.html
+++ b/web_app/templates/login.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
+{% from 'macros.html' import header_with_add %}
 {% block content %}
-<h2>Prisijungimas</h2>
+{{ header_with_add('Prisijungimas') }}
 <form method="post">
     <label>El. paštas: <input type="text" name="username"></label><br>
     <label>Slaptažodis: <input type="password" name="password"></label><br>

--- a/web_app/templates/planavimas.html
+++ b/web_app/templates/planavimas.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
+{% from 'macros.html' import header_with_add %}
 {% block content %}
-<h2>Planavimas</h2>
+{{ header_with_add('Planavimas') }}
 <label for="group-select">Ekspedicijos grupė:</label>
 <select id="group-select"></select>
 <table id="plan-table" class="display" style="width:100%"></table>

--- a/web_app/templates/priekabos_form.html
+++ b/web_app/templates/priekabos_form.html
@@ -1,6 +1,8 @@
 {% extends 'base.html' %}
+{% from 'macros.html' import header_with_add %}
 {% block content %}
-<h2>{% if data.id %}Redaguoti priekabą{% else %}Nauja priekaba{% endif %}</h2>
+{% set form_title = 'Redaguoti priekabą' if data.id else 'Nauja priekaba' %}
+{{ header_with_add(form_title) }}
 <form method="post" action="/priekabos/save">
     <input type="hidden" name="pid" value="{{ data.id or 0 }}">
     <div class="form-grid">

--- a/web_app/templates/register.html
+++ b/web_app/templates/register.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
+{% from 'macros.html' import header_with_add %}
 {% block content %}
-<h2>Registracija</h2>
+{{ header_with_add('Registracija') }}
 <form method="post">
     <label>El. paštas: <input type="text" name="username"></label><br>
     <label>Slaptažodis: <input type="password" name="password"></label><br>

--- a/web_app/templates/registracijos_list.html
+++ b/web_app/templates/registracijos_list.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
+{% from 'macros.html' import header_with_add %}
 {% block content %}
-<h2>Laukiantys naudotojai</h2>
+{{ header_with_add('Laukiantys naudotojai') }}
 <button id="reg-csv">CSV</button>
 <table id="reg-table" class="display" style="width:100%">
     <thead>
@@ -16,7 +17,7 @@
         </tr>
     </thead>
 </table>
-<h2>Aktyvūs naudotojai</h2>
+{{ header_with_add('Aktyvūs naudotojai') }}
 <button id="active-csv">CSV</button>
 <table id="active-table" class="display" style="width:100%">
     <thead>

--- a/web_app/templates/roles_list.html
+++ b/web_app/templates/roles_list.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
+{% from 'macros.html' import header_with_add %}
 {% block content %}
-<h2>Rolės</h2>
+{{ header_with_add('Rolės') }}
 <table id="roles-table" class="display" style="width:100%">
     <thead>
         <tr>

--- a/web_app/templates/settings.html
+++ b/web_app/templates/settings.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
+{% from 'macros.html' import header_with_add %}
 {% block content %}
-<h2>Numatytieji priekabų tipai</h2>
+{{ header_with_add('Numatytieji priekabų tipai') }}
 <form id="defaults-form" method="post" action="/settings/save">
     <label>Įmonė: <input type="text" id="imone-field" name="imone" value="A"></label>
     <div id="rows"></div>

--- a/web_app/templates/trailer_specs_form.html
+++ b/web_app/templates/trailer_specs_form.html
@@ -1,6 +1,8 @@
 {% extends 'base.html' %}
+{% from 'macros.html' import header_with_add %}
 {% block content %}
-<h2>{% if data.id %}Redaguoti specifikaciją{% else %}Nauja specifikacija{% endif %}</h2>
+{% set form_title = 'Redaguoti specifikaciją' if data.id else 'Nauja specifikacija' %}
+{{ header_with_add(form_title) }}
 <form method="post" action="/trailer-specs/save">
     <input type="hidden" name="sid" value="{{ data.id or 0 }}">
     <div class="form-grid">

--- a/web_app/templates/trailer_types_form.html
+++ b/web_app/templates/trailer_types_form.html
@@ -1,6 +1,8 @@
 {% extends 'base.html' %}
+{% from 'macros.html' import header_with_add %}
 {% block content %}
-<h2>{% if data.id %}Redaguoti priekabos tipą{% else %}Naujas priekabos tipas{% endif %}</h2>
+{% set form_title = 'Redaguoti priekabos tipą' if data.id else 'Naujas priekabos tipas' %}
+{{ header_with_add(form_title) }}
 <form method="post" action="/trailer-types/save">
     <input type="hidden" name="tid" value="{{ data.id or 0 }}">
     <label>Pavadinimas: <input type="text" name="reiksme" value="{{ data.reiksme or '' }}"></label><br>

--- a/web_app/templates/updates_form.html
+++ b/web_app/templates/updates_form.html
@@ -1,6 +1,8 @@
 {% extends 'base.html' %}
+{% from 'macros.html' import header_with_add %}
 {% block content %}
-<h2>{% if data.id %}Redaguoti įrašą{% else %}Atnaujinti krovinį{% endif %}</h2>
+{% set form_title = 'Redaguoti įrašą' if data.id else 'Atnaujinti krovinį' %}
+{{ header_with_add(form_title) }}
 <form method="post" action="/updates/save">
     <input type="hidden" name="uid" value="{{ data.id or 0 }}">
     <input type="hidden" name="vilkiko_numeris" value="{{ data.vilkiko_numeris }}">

--- a/web_app/templates/updates_list.html
+++ b/web_app/templates/updates_list.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
+{% from 'macros.html' import header_with_add %}
 {% block content %}
-<h2>Padėties atnaujinimai</h2>
+{{ header_with_add('Padėties atnaujinimai') }}
 <label>Transporto vadybininkas:
     <select id="manager-select">
         {% for m in managers %}

--- a/web_app/templates/vairuotojai_form.html
+++ b/web_app/templates/vairuotojai_form.html
@@ -1,6 +1,8 @@
 {% extends 'base.html' %}
+{% from 'macros.html' import header_with_add %}
 {% block content %}
-<h2>{% if data.id %}Redaguoti vairuotoją{% else %}Naujas vairuotojas{% endif %}</h2>
+{% set form_title = 'Redaguoti vairuotoją' if data.id else 'Naujas vairuotojas' %}
+{{ header_with_add(form_title) }}
 <form method="post" action="/vairuotojai/save">
     <input type="hidden" name="did" value="{{ data.id or 0 }}">
     <input type="hidden" name="kadencijos_pabaiga" value="{{ data.kadencijos_pabaiga or '' }}">

--- a/web_app/templates/vilkikai_form.html
+++ b/web_app/templates/vilkikai_form.html
@@ -1,6 +1,8 @@
 {% extends 'base.html' %}
+{% from 'macros.html' import header_with_add %}
 {% block content %}
-<h2>{% if data.id %}Redaguoti vilkiką{% else %}Naujas vilkikas{% endif %}</h2>
+{% set form_title = 'Redaguoti vilkiką' if data.id else 'Naujas vilkikas' %}
+{{ header_with_add(form_title) }}
 <form method="post" action="/vilkikai/save">
     <input type="hidden" name="vid" value="{{ data.id or 0 }}">
     <div class="form-grid">


### PR DESCRIPTION
## Summary
- use `header_with_add` macro across all templates
- mark completed migration step in docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686771556d408324969cb5c00822c294