### PR TITLE
Update role checks in base template

### DIFF
--- a/web_app/templates/base.html
+++ b/web_app/templates/base.html
@@ -23,13 +23,13 @@
         <a href="/klientai">Klientai</a> |
         <a href="/planavimas">Planavimas</a> |
         <a href="/trailer-types">Priekabų tipai</a>
-        {% if 'ADMIN' in roles %} |
+        {% if 'admin' in roles %} |
         <a href="/trailer-specs">Priekabų spec.</a> |
         <a href="/settings">Nustatymai</a>{% endif %}
-        {% if 'ADMIN' in roles or 'COMPANY_ADMIN' in roles %} |
+        {% if 'admin' in roles or 'company_admin' in roles %} |
         <a href="/registracijos">Registracijos</a>{% endif %} |
         <a href="/updates">Atnaujinimai</a>
-        {% if 'ADMIN' in roles %} |
+        {% if 'admin' in roles %} |
         <a href="/audit">Auditas</a> |
         <a href="/roles">Rolės</a>{% endif %}
         {% if request.session.get('user_id') %} |


### PR DESCRIPTION
## Summary
- use lowercase role strings when checking session roles in base template

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686776e84c4c83249d36437d59b1f2f1