### PR TITLE
Rename roles endpoint

### DIFF
--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -670,6 +670,16 @@ def test_roles_endpoints(tmp_path):
     assert "name" in resp.text.splitlines()[0]
 
 
+def test_roles_full_endpoint(tmp_path):
+    client = create_client(tmp_path)
+    resp = client.get("/api/roles-full")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert isinstance(data, list) and len(data) > 0
+    first = data[0]
+    assert "id" in first and "name" in first
+
+
 def test_group_regions(tmp_path):
     client = create_client(tmp_path)
     db_path = tmp_path / "app.db"

--- a/web_app/routers/roles.py
+++ b/web_app/routers/roles.py
@@ -17,7 +17,7 @@ def roles_list(request: Request, auth: None = Depends(require_roles(Role.ADMIN))
     return templates.TemplateResponse("roles_list.html", {"request": request})
 
 
-@router.get("/api/roles")
+@router.get("/api/roles-full")
 def roles_api(db: tuple[sqlite3.Connection, sqlite3.Cursor] = Depends(get_db)):
     """Grąžina rolių sąrašą JSON formatu."""
     conn, cursor = db

--- a/web_app/templates/roles_list.html
+++ b/web_app/templates/roles_list.html
@@ -13,7 +13,7 @@
 <script>
 $(document).ready(function() {
     $('#roles-table').DataTable({
-        ajax: '/api/roles',
+        ajax: '/api/roles-full',
         columns: [
             { data: 'id' },
             { data: 'name' }


### PR DESCRIPTION
## Summary
- rename `/api/roles` endpoint in web app to `/api/roles-full`
- update roles list template accordingly
- add regression test for new endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for fastapi/bcrypt)*

------
https://chatgpt.com/codex/tasks/task_e_686778d8dfe88324a4a20f2914a5f2cc