### PR TITLE
Add user role management

### DIFF
--- a/tests/test_user_roles.py
+++ b/tests/test_user_roles.py
@@ -1,0 +1,64 @@
+import os
+import sqlite3
+from modules import login, auth_utils
+from modules.roles import Role
+from tests.test_web_app import create_client
+
+
+def test_update_user_roles(tmp_path):
+    client = create_client(tmp_path)
+    db_path = tmp_path / "app.db"
+    conn = sqlite3.connect(db_path)
+    c = conn.cursor()
+    pw = auth_utils.hash_password("pass")
+    c.execute(
+        "INSERT INTO users (username, password_hash, imone, aktyvus) VALUES (?,?,?,1)",
+        ("u@a.com", pw, "A"),
+    )
+    uid = c.lastrowid
+    conn.commit()
+    conn.close()
+
+    resp = client.post(f"/api/user-roles/{uid}", json={"roles": ["user"]})
+    assert resp.status_code == 200
+
+    conn = sqlite3.connect(db_path)
+    c = conn.cursor()
+    c.execute(
+        "SELECT r.name FROM user_roles ur JOIN roles r ON ur.role_id=r.id WHERE ur.user_id=?",
+        (uid,),
+    )
+    roles = {r[0] for r in c.fetchall()}
+    conn.close()
+    assert roles == {"user"}
+
+
+def test_user_roles_forbidden(tmp_path):
+    client = create_client(tmp_path, do_login=False)
+    db_path = tmp_path / "app.db"
+    conn = sqlite3.connect(db_path)
+    c = conn.cursor()
+    pw = auth_utils.hash_password("pass")
+    c.execute(
+        "INSERT INTO users (username, password_hash, imone, aktyvus) VALUES (?,?,?,1)",
+        ("user1@a.com", pw, "A"),
+    )
+    uid1 = c.lastrowid
+    login.assign_role(conn, c, uid1, Role.USER)
+    c.execute(
+        "INSERT INTO users (username, password_hash, imone, aktyvus) VALUES (?,?,?,1)",
+        ("user2@a.com", pw, "A"),
+    )
+    uid2 = c.lastrowid
+    conn.commit()
+    conn.close()
+
+    resp = client.post(
+        "/login",
+        data={"username": "user1@a.com", "password": "pass"},
+        allow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    resp = client.post(f"/api/user-roles/{uid2}", json={"roles": ["user"]})
+    assert resp.status_code == 403

--- a/web_app/routers/__init__.py
+++ b/web_app/routers/__init__.py
@@ -20,6 +20,7 @@ from .updates import router as updates_router
 from .health import router as health_router
 from .constants import router as constants_router
 from .roles import router as roles_router
+from .user_roles import router as user_roles_router
 
 router = APIRouter()
 for r in [
@@ -43,5 +44,6 @@ for r in [
     health_router,
     constants_router,
     roles_router,
+    user_roles_router,
 ]:
     router.include_router(r)

--- a/web_app/routers/user_roles.py
+++ b/web_app/routers/user_roles.py
@@ -1,0 +1,61 @@
+from fastapi import APIRouter, Request, Depends, HTTPException
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+import sqlite3
+from ..utils import get_db
+from ..auth import require_roles
+from modules.roles import Role
+from modules.login import assign_role, get_user_roles
+
+router = APIRouter()
+templates = Jinja2Templates(directory="web_app/templates")
+
+
+@router.get("/user-roles", response_class=HTMLResponse)
+def user_roles_page(
+    request: Request,
+    db: tuple[sqlite3.Connection, sqlite3.Cursor] = Depends(get_db),
+    auth: None = Depends(require_roles(Role.ADMIN, Role.COMPANY_ADMIN)),
+):
+    conn, cursor = db
+    rows = cursor.execute("SELECT id, username FROM users ORDER BY username").fetchall()
+    users = []
+    for uid, username in rows:
+        roles = get_user_roles(cursor, uid)
+        users.append({"id": uid, "username": username, "roles": roles})
+    return templates.TemplateResponse("user_roles.html", {"request": request, "users": users})
+
+
+@router.get("/api/user-roles/{uid}")
+def user_roles_get(
+    uid: int,
+    db: tuple[sqlite3.Connection, sqlite3.Cursor] = Depends(get_db),
+    auth: None = Depends(require_roles(Role.ADMIN, Role.COMPANY_ADMIN)),
+):
+    conn, cursor = db
+    row = cursor.execute("SELECT id FROM users WHERE id=?", (uid,)).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="Not found")
+    roles = get_user_roles(cursor, uid)
+    return {"roles": roles}
+
+
+@router.post("/api/user-roles/{uid}")
+async def user_roles_post(
+    request: Request,
+    uid: int,
+    db: tuple[sqlite3.Connection, sqlite3.Cursor] = Depends(get_db),
+    auth: None = Depends(require_roles(Role.ADMIN, Role.COMPANY_ADMIN)),
+):
+    conn, cursor = db
+    row = cursor.execute("SELECT id FROM users WHERE id=?", (uid,)).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="Not found")
+    data = await request.json()
+    roles = data.get("roles", []) if isinstance(data, dict) else []
+    cursor.execute("DELETE FROM user_roles WHERE user_id=?", (uid,))
+    for r in roles:
+        if r in Role._value2member_map_:
+            assign_role(conn, cursor, uid, Role(r))
+    conn.commit()
+    return {"status": "ok"}

--- a/web_app/templates/base.html
+++ b/web_app/templates/base.html
@@ -32,6 +32,8 @@
         {% if 'admin' in roles %} |
         <a href="/audit">Auditas</a> |
         <a href="/roles">Rolės</a>{% endif %}
+        {% if 'admin' in roles or 'company_admin' in roles %} |
+        <a href="/user-roles">Vartotojų rolės</a>{% endif %}
         {% if request.session.get('user_id') %} |
         Prisijungęs: {{ request.session.get('username') }} (<a href="/logout">Atsijungti</a>)
         {% else %} |

--- a/web_app/templates/user_roles.html
+++ b/web_app/templates/user_roles.html
@@ -1,0 +1,45 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Vartotojų rolės</h2>
+<table id="roles-table" class="display" style="width:100%">
+    <thead>
+        <tr>
+            <th>ID</th>
+            <th>Vartotojas</th>
+            <th>Rolės</th>
+            <th>Veiksmai</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for u in users %}
+        <tr>
+            <td>{{ u.id }}</td>
+            <td>{{ u.username }}</td>
+            <td>{{ u.roles|join(', ') }}</td>
+            <td><button class="edit-btn" data-id="{{ u.id }}">Keisti</button></td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+<script>
+$(document).ready(function() {
+    $('#roles-table').DataTable();
+    $('.edit-btn').on('click', async function() {
+        const uid = $(this).data('id');
+        const resp = await fetch('/api/user-roles/' + uid);
+        if (!resp.ok) return;
+        const data = await resp.json();
+        const current = data.roles.join(',');
+        const val = prompt('Rolės (kableliais atskirtos)', current);
+        if (val === null) return;
+        const roles = val.split(',').map(r => r.trim()).filter(r => r);
+        await fetch('/api/user-roles/' + uid, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ roles })
+        });
+        location.reload();
+    });
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add user roles management page and routes
- link new page from the main menu
- tests for updating user roles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68677b658304832490b2c763f91ddbaa