### PR TITLE
Fix kroviniai edit form missing trans_rows

### DIFF
--- a/web_app/routers/kroviniai.py
+++ b/web_app/routers/kroviniai.py
@@ -118,6 +118,10 @@ def kroviniai_edit_form(
             "SELECT vardas, pavarde FROM darbuotojai WHERE pareigybe=?",
             ("Ekspedicijos vadybininkas",),
         ).fetchall()
+        trans_rows = cursor.execute(
+            "SELECT vardas, pavarde FROM darbuotojai WHERE pareigybe=?",
+            ("Transporto vadybininkas",),
+        ).fetchall()
     else:
         imone = request.session.get("imone", "")
         klientai = [


### PR DESCRIPTION
## Summary
- ensure `trans_rows` is defined for admin users in `kroviniai_edit_form`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68679418d08c8324a948a12df40a594d