### PR TITLE
Implement group deletion

### DIFF
--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -785,3 +785,32 @@ def test_trailer_types_delete(tmp_path):
     assert resp.status_code == 303
     resp = client.get("/api/trailer-types")
     assert resp.json() == {"data": []}
+
+
+def test_grupes_delete(tmp_path):
+    client = create_client(tmp_path)
+    form = {
+        "gid": "0",
+        "numeris": "GR1",
+        "pavadinimas": "GR1",
+        "aprasymas": "",
+        "imone": "A",
+    }
+    resp = client.post("/grupes/save", data=form, allow_redirects=False)
+    assert resp.status_code == 303
+    resp = client.get("/api/grupes")
+    data = resp.json()["data"]
+    assert len(data) == 1
+    gid = data[0]["id"]
+    resp = client.post(
+        "/group-regions/add",
+        data={"grupe_id": str(gid), "regionai": "LT"},
+        allow_redirects=False,
+    )
+    assert resp.status_code == 303
+    resp = client.get(f"/grupes/{gid}/delete", allow_redirects=False)
+    assert resp.status_code == 303
+    resp = client.get("/api/grupes")
+    assert resp.json() == {"data": []}
+    resp = client.get(f"/api/group-regions?gid={gid}")
+    assert resp.json() == {"data": []}

--- a/web_app/routers/grupes.py
+++ b/web_app/routers/grupes.py
@@ -118,3 +118,19 @@ def grupes_csv(
     return Response(content=csv_data, media_type="text/csv", headers=headers)
 
 
+@router.get("/grupes/{gid}/delete")
+def grupes_delete(
+    gid: int,
+    request: Request,
+    db: tuple[sqlite3.Connection, sqlite3.Cursor] = Depends(get_db),
+):
+    conn, cursor = db
+    cursor.execute("DELETE FROM grupiu_regionai WHERE grupe_id=?", (gid,))
+    cursor.execute("DELETE FROM grupes WHERE id=?", (gid,))
+    if cursor.rowcount == 0:
+        raise HTTPException(status_code=404, detail="Not found")
+    conn.commit()
+    log_action(conn, cursor, request.session.get("user_id"), "delete", "grupes", gid)
+    return RedirectResponse("/grupes", status_code=303)
+
+

--- a/web_app/templates/grupes_list.html
+++ b/web_app/templates/grupes_list.html
@@ -28,7 +28,8 @@ $(document).ready(function() {
             { data: 'numeris' },
             { data: 'pavadinimas' },
             { data: null, render: function (data, type, row) {
-                return '<a href="/grupes/' + row.id + '/edit">Edit</a>';
+                return '<a href="/grupes/' + row.id + '/edit">Edit</a> '
+                     + '<a href="/grupes/' + row.id + '/delete">Šalinti</a>';
             }}
         ]
     });


### PR DESCRIPTION
## Summary
- allow removing groups in the web app
- display Delete action in groups table
- test deleting groups

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686aa0b92620832494cbaf19bc805605