### PR TITLE
Ensure company stays fixed for users

### DIFF
--- a/web_app/routers/darbuotojai.py
+++ b/web_app/routers/darbuotojai.py
@@ -83,6 +83,8 @@ def darbuotojai_save(
     db: tuple[sqlite3.Connection, sqlite3.Cursor] = Depends(get_db),
 ):
     conn, cursor = db
+    if not user_has_role(request, cursor, Role.ADMIN):
+        imone = request.session.get("imone")
     akt = 1 if aktyvus else 0
     if did:
         cursor.execute(

--- a/web_app/routers/grupes.py
+++ b/web_app/routers/grupes.py
@@ -27,8 +27,9 @@ def grupes_list(request: Request):
 
 @router.get("/grupes/add", response_class=HTMLResponse)
 def grupes_add_form(request: Request):
+    imone = request.session.get("imone", "")
     return templates.TemplateResponse(
-        "grupes_form.html", {"request": request, "data": {}}
+        "grupes_form.html", {"request": request, "data": {"imone": imone}}
     )
 
 
@@ -39,6 +40,8 @@ def grupes_edit_form(
     db: tuple[sqlite3.Connection, sqlite3.Cursor] = Depends(get_db),
 ):
     conn, cursor = db
+    if not user_has_role(request, cursor, Role.ADMIN):
+        imone = request.session.get("imone")
     row = cursor.execute("SELECT * FROM grupes WHERE id=?", (gid,)).fetchone()
     if not row:
         raise HTTPException(status_code=404, detail="Not found")
@@ -60,6 +63,8 @@ def grupes_save(
     db: tuple[sqlite3.Connection, sqlite3.Cursor] = Depends(get_db),
 ):
     conn, cursor = db
+    if not user_has_role(request, cursor, Role.ADMIN):
+        imone = request.session.get("imone")
     if gid:
         cursor.execute(
             "UPDATE grupes SET numeris=?, pavadinimas=?, aprasymas=?, imone=? WHERE id=?",

--- a/web_app/routers/klientai.py
+++ b/web_app/routers/klientai.py
@@ -72,6 +72,8 @@ def klientai_save(
     db: tuple[sqlite3.Connection, sqlite3.Cursor] = Depends(get_db),
 ):
     conn, cursor = db
+    if not user_has_role(request, cursor, Role.ADMIN):
+        imone = request.session.get("imone")
     musu, liks = compute_limits(cursor, vat_numeris, coface_limitas)
     if cid:
         cursor.execute(

--- a/web_app/routers/kroviniai.py
+++ b/web_app/routers/kroviniai.py
@@ -195,7 +195,7 @@ def kroviniai_save(
     db: tuple[sqlite3.Connection, sqlite3.Cursor] = Depends(get_db),
 ):
     conn, cursor = db
-    if not imone:
+    if not user_has_role(request, cursor, Role.ADMIN):
         imone = request.session.get("imone")
     cols = [
         "klientas",

--- a/web_app/routers/priekabos.py
+++ b/web_app/routers/priekabos.py
@@ -52,7 +52,12 @@ def priekabos_add_form(
     ]
     return templates.TemplateResponse(
         "priekabos_form.html",
-        {"request": request, "data": {}, "tipai": tipai, "markes": markes},
+        {
+            "request": request,
+            "data": {"imone": imone},
+            "tipai": tipai,
+            "markes": markes,
+        },
     )
 
 
@@ -112,6 +117,8 @@ def priekabos_save(
     db: tuple[sqlite3.Connection, sqlite3.Cursor] = Depends(get_db),
 ):
     conn, cursor = db
+    if not user_has_role(request, cursor, Role.ADMIN):
+        imone = request.session.get("imone")
     if pid:
         cursor.execute(
             "UPDATE priekabos SET priekabu_tipas=?, numeris=?, marke=?, pagaminimo_metai=?, tech_apziura=?, draudimas=?, imone=? WHERE id=?",

--- a/web_app/routers/vairuotojai.py
+++ b/web_app/routers/vairuotojai.py
@@ -27,11 +27,12 @@ def vairuotojai_list(request: Request):
 
 @router.get("/vairuotojai/add", response_class=HTMLResponse)
 def vairuotojai_add_form(request: Request):
+    imone = request.session.get("imone", "")
     return templates.TemplateResponse(
         "vairuotojai_form.html",
         {
             "request": request,
-            "data": {},
+            "data": {"imone": imone},
             "tautybes": DRIVER_NATIONALITIES,
         },
     )
@@ -73,6 +74,8 @@ def vairuotojai_save(
     db: tuple[sqlite3.Connection, sqlite3.Cursor] = Depends(get_db),
 ):
     conn, cursor = db
+    if not user_has_role(request, cursor, Role.ADMIN):
+        imone = request.session.get("imone")
     if did:
         cursor.execute(
             "UPDATE vairuotojai SET vardas=?, pavarde=?, gimimo_metai=?, tautybe=?, kadencijos_pabaiga=?, atostogu_pabaiga=?, imone=? WHERE id=?",

--- a/web_app/routers/vilkikai.py
+++ b/web_app/routers/vilkikai.py
@@ -23,6 +23,7 @@ def vilkikai_add_form(
     db: tuple[sqlite3.Connection, sqlite3.Cursor] = Depends(get_db),
 ):
     conn, cursor = db
+    imone = request.session.get("imone", "")
     if user_has_role(request, cursor, Role.ADMIN):
         trailers = [r[0] for r in cursor.execute("SELECT numeris FROM priekabos").fetchall()]
         vair_rows = cursor.execute("SELECT id, vardas, pavarde FROM vairuotojai").fetchall()
@@ -48,7 +49,7 @@ def vilkikai_add_form(
     vadybininkai = [f"{r[0]} {r[1]}" for r in vadyb_rows]
     context = {
         "request": request,
-        "data": {},
+        "data": {"imone": imone},
         "trailers": trailers,
         "markes": markes,
         "vairuotojai": vairuotojai,
@@ -142,6 +143,8 @@ def vilkikai_save(
     db: tuple[sqlite3.Connection, sqlite3.Cursor] = Depends(get_db),
 ):
     conn, cursor = db
+    if not user_has_role(request, cursor, Role.ADMIN):
+        imone = request.session.get("imone")
     drivers = ", ".join(filter(None, [vairuotojas1, vairuotojas2]))
     if vid:
         cursor.execute(

--- a/web_app/templates/base.html
+++ b/web_app/templates/base.html
@@ -35,7 +35,7 @@
         {% if 'admin' in roles or 'company_admin' in roles %} |
         <a href="/user-roles">Vartotojų rolės</a>{% endif %}
         {% if request.session.get('user_id') %} |
-        Prisijungęs: {{ request.session.get('username') }} (<a href="/logout">Atsijungti</a>)
+        Prisijungęs: {{ request.session.get('username') }} - Įmonė: {{ request.session.get('imone') }} (<a href="/logout">Atsijungti</a>)
         {% else %} |
         <a href="/login">Prisijungti</a>{% endif %}
     </nav>

--- a/web_app/templates/grupes_form.html
+++ b/web_app/templates/grupes_form.html
@@ -15,9 +15,7 @@
         <label class="full-width">Aprašymas
             <textarea name="aprasymas">{{ data.aprasymas or '' }}</textarea>
         </label>
-        <label class="full-width">Įmonė
-            <input type="text" name="imone" value="{{ data.imone or '' }}">
-        </label>
+        <input type="hidden" name="imone" value="{{ data.imone or '' }}">
     </div>
     <button type="submit">💾 Išsaugoti grupę</button>
     <a href="/grupes">← Atšaukti</a>

--- a/web_app/templates/priekabos_form.html
+++ b/web_app/templates/priekabos_form.html
@@ -34,9 +34,7 @@
         <label>Draudimas
             <input type="date" name="draudimas" value="{{ data.draudimas or '' }}">
         </label>
-        <label class="full-width">Įmonė
-            <input type="text" name="imone" value="{{ data.imone or '' }}">
-        </label>
+        <input type="hidden" name="imone" value="{{ data.imone or '' }}">
     </div>
     <button type="submit">💾 Išsaugoti priekabą</button>
     <a href="/priekabos">← Grįžti į sąrašą</a>

--- a/web_app/templates/vilkikai_form.html
+++ b/web_app/templates/vilkikai_form.html
@@ -61,9 +61,7 @@
                 {% endfor %}
             </select>
         </label>
-        <label class="full-width">Įmonė
-            <input type="text" name="imone" value="{{ data.imone or '' }}">
-        </label>
+        <input type="hidden" name="imone" value="{{ data.imone or '' }}">
     </div>
     <button type="submit">💾 Išsaugoti vilkiką</button>
     <a href="/vilkikai">← Grįžti į sąrašą</a>


### PR DESCRIPTION
## Summary
- show logged in user's company in the nav bar
- hide company inputs in vehicle, trailer and group forms
- keep company value from the session when saving data

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686aa2182f1c8324b3f11a01f0408455