### PR TITLE
Implement manager assignment for group regions

### DIFF
--- a/db.py
+++ b/db.py
@@ -161,7 +161,7 @@ def _setup_default_exp_groups(conn: sqlite3.Connection, c: sqlite3.Cursor) -> No
             )
             if not c.fetchone():
                 c.execute(
-                    "INSERT INTO grupiu_regionai (grupe_id, regiono_kodas) VALUES (?,?)",
+                    "INSERT INTO grupiu_regionai (grupe_id, regiono_kodas, vadybininkas_id) VALUES (?,?,NULL)",
                     (gid, code),
                 )
     conn.commit()
@@ -439,9 +439,15 @@ def init_db(db_path: str | None = None):
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             grupe_id      INTEGER NOT NULL,
             regiono_kodas TEXT NOT NULL,
+            vadybininkas_id INTEGER,
             FOREIGN KEY (grupe_id) REFERENCES grupes(id)
         )
     """)
+    c.execute("PRAGMA table_info(grupiu_regionai)")
+    cols = [row[1] for row in c.fetchall()]
+    if "vadybininkas_id" not in cols:
+        c.execute("ALTER TABLE grupiu_regionai ADD COLUMN vadybininkas_id INTEGER")
+        conn.commit()
 
     # Insert default expedition groups and their regions
     _setup_default_exp_groups(conn, c)

--- a/web_app/templates/group_regions.html
+++ b/web_app/templates/group_regions.html
@@ -13,6 +13,7 @@
             <th>ID</th>
             <th>Regiono kodas</th>
             <th>Kitos grupės</th>
+            <th>Vadybininkas</th>
             <th>Veiksmai</th>
         </tr>
     </thead>
@@ -21,11 +22,15 @@
     <input type="hidden" name="grupe_id" id="grupe-id-input">
     <label>Nauji regionai (pvz. FR10;DE20)</label>
     <textarea name="regionai" id="regionai" rows="2" style="width:100%;"></textarea>
+    <label>Vadybininkas
+        <select name="vadybininkas_id" id="vadybininkas-select"></select>
+    </label>
     <button type="submit">Pridėti</button>
 </form>
 <script>
 $(document).ready(function() {
     let table;
+    let employees = [];
     function initTable(){
         table = $('#region-table').DataTable({
             ajax: {
@@ -37,11 +42,28 @@ $(document).ready(function() {
                 { data: 'regiono_kodas' },
                 { data: 'kitos_grupes', defaultContent: '' },
                 { data: null, render: function(data,type,row){
+                    let options = '<option value="">--</option>';
+                    employees.forEach(e => {
+                        const sel = e.id === row.vadybininkas_id ? 'selected' : '';
+                        options += `<option value="${e.id}" ${sel}>${e.vardas} ${e.pavarde}</option>`;
+                    });
+                    return `<select class="vadyb-select" data-rid="${row.id}">${options}</select>`;
+                }},
+                { data: null, render: function(data,type,row){
                     const gid = $('#grupe-select').val();
                     return `<a href="/group-regions/${row.id}/delete?gid=${gid}">Šalinti</a>`;
                 }}
             ]
         });
+    }
+    async function loadEmployees(){
+        const resp = await fetch('/api/darbuotojai');
+        const data = await resp.json();
+        employees = data.data;
+        const sel = $('#vadybininkas-select');
+        sel.empty();
+        sel.append('<option value="">--</option>');
+        employees.forEach(e => sel.append(`<option value="${e.id}">${e.vardas} ${e.pavarde}</option>`));
     }
     async function loadGroups(){
         const resp = await fetch('/api/grupes');
@@ -73,7 +95,16 @@ $(document).ready(function() {
             $('#regionai').val('');
         }
     });
-    loadGroups();
+    loadEmployees().then(loadGroups);
+
+    $(document).on('change', '.vadyb-select', async function(){
+        const rid = $(this).data('rid');
+        const gid = $('#grupe-select').val();
+        const vid = $(this).val();
+        const body = `vadybininkas_id=${vid}&gid=${gid}`;
+        await fetch(`/group-regions/${rid}/assign`, {method:'POST', headers:{'Content-Type':'application/x-www-form-urlencoded'}, body});
+        table.ajax.reload(null,false);
+    });
 });
 </script>
 <style>

--- a/web_app/utils/__init__.py
+++ b/web_app/utils/__init__.py
@@ -97,6 +97,7 @@ EXPECTED_GRUPES_COLUMNS = {
 EXPECTED_GRUPIU_REGIONAI_COLUMNS = {
     "grupe_id": "INTEGER",
     "regiono_kodas": "TEXT",
+    "vadybininkas_id": "INTEGER",
 }
 
 EXPECTED_VILKIKU_DARBOLAikai_COLUMNS = {


### PR DESCRIPTION
## Summary
- support `vadybininkas_id` in group region table
- allow assigning managers to regions via new endpoint and UI
- expose manager column in group region CSV export
- test assignment of manager to a region

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686acf4f58488324af2653ea4a9a4277