### PR TITLE
Improve region selector UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains a FastAPI based application for logistics companies. The app manages shipments, vehicles and staff information in a single dashboard and stores all data in a local SQLite database.
 
 The web interface is located in the `web_app` directory and relies on DataTables for an Excel-style look. Initially it only supported shipment management but now also includes trucks, trailers, employees, groups, clients, drivers, trailer type management, trailer assignment and an audit log section with a simple login/registration system. Naujausioje versijoje taip pat galima atsisiųsti darbuotojų, grupių, klientų, vairuotojų bei priekabų specifikacijų, numatytų priekabų tipų, laukiančių registracijų ir aktyvių naudotojų sąrašus CSV formatu. Šablonuose naudojamas bendras Jinja makro `header_with_add`, kuris užtikrina vienodą antraštės ir "Pridėti" mygtuko išdėstymą.
-Regionų priskyrimas vadybininkams dabar atliekamas darbuotojo redagavimo formoje. Pasirinkus grupę rodomi jos regionai su varnelėmis ir išsaugojus pažymėjimus atnaujinami priskyrimai.
+Regionų priskyrimas vadybininkams dabar atliekamas darbuotojo redagavimo formoje. Pasirinkus grupę rodomi jos regionai kaip paspaudžiami mygtukai, kurie pažymėti pažaliuoja. Išsaugojus atnaujinami priskyrimai.
 
 See [MIGRATION.md](MIGRATION.md) for a short summary of the migration progress.
 

--- a/web_app/templates/darbuotojai_form.html
+++ b/web_app/templates/darbuotojai_form.html
@@ -38,11 +38,11 @@
     {% if group %}
     <p>Darbuotojo grupė: {{ group.pavadinimas or group.numeris }}</p>
         {% if group_regions %}
-        <div style="margin-bottom:10px;">
+        <div class="region-container" style="margin-bottom:10px;">
             {% for r in group_regions %}
-            <label style="margin-right:10px;">
+            <label class="region-choice" style="margin-right:10px;">
                 <input type="checkbox" name="region_ids" value="{{ r.id }}" {% if r.checked %}checked{% endif %}>
-                {{ r.regiono_kodas }}
+                <span>{{ r.regiono_kodas }}</span>
             </label>
             {% endfor %}
         </div>
@@ -63,6 +63,23 @@
 .form-grid label {
     display: flex;
     flex-direction: column;
+}
+
+.region-choice input[type=checkbox] {
+    display: none;
+}
+
+.region-choice span {
+    display: inline-block;
+    padding: 4px 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background: #f0f0f0;
+    cursor: pointer;
+}
+
+.region-choice input[type=checkbox]:checked + span {
+    background: #c8f7c5;
 }
 </style>
 {% endblock %}


### PR DESCRIPTION
## Summary
- render employee region assignments as button-like labels
- highlight selected regions with green
- document new region selector behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686ae20af4c083249af8ac9214a2fdbd