### PR TITLE
Add interactive map for group region selection

### DIFF
--- a/web_app/static/nuts_regions.geojson
+++ b/web_app/static/nuts_regions.geojson
@@ -1,0 +1,37 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {"NUTS_ID": "LT01"},
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [22.0, 55.0],
+            [23.0, 55.0],
+            [23.0, 56.0],
+            [22.0, 56.0],
+            [22.0, 55.0]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {"NUTS_ID": "LT02"},
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [23.0, 55.0],
+            [24.0, 55.0],
+            [24.0, 56.0],
+            [23.0, 56.0],
+            [23.0, 55.0]
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/web_app/templates/group_regions.html
+++ b/web_app/templates/group_regions.html
@@ -18,15 +18,52 @@
         </tr>
     </thead>
 </table>
+<div id="map" style="height:400px; margin-top:10px;"></div>
 <form id="add-form" style="margin-top:10px;">
     <input type="hidden" name="grupe_id" id="grupe-id-input">
     <label>Nauji regionai (pvz. FR10;DE20)</label>
     <textarea name="regionai" id="regionai" rows="2" style="width:100%;"></textarea>
     <button type="submit">Pridėti</button>
 </form>
+<link
+    rel="stylesheet"
+    href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+/>
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script>
 $(document).ready(function() {
     let table;
+    const selected = new Set();
+    const map = L.map('map').setView([55.2, 23.9], 6);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        maxZoom: 10,
+        attribution: '© OpenStreetMap'
+    }).addTo(map);
+    function updateField(){
+        $('#regionai').val(Array.from(selected).join(';'));
+    }
+    fetch('/static/nuts_regions.geojson')
+        .then(r => r.json())
+        .then(data => {
+            L.geoJSON(data, {
+                onEachFeature: function(feature, layer){
+                    const code = feature.properties.NUTS_ID || feature.properties.id;
+                    if(!code) return;
+                    layer.on('click', function(){
+                        if(selected.has(code)){
+                            selected.delete(code);
+                            layer.setStyle({fillColor: '#3388ff'});
+                        } else {
+                            selected.add(code);
+                            layer.setStyle({fillColor: '#00ff00'});
+                        }
+                        updateField();
+                    });
+                    layer.bindTooltip(code);
+                },
+                style:{color:'#3388ff',weight:1,fillOpacity:0.4}
+            }).addTo(map);
+        });
     function initTable(){
         table = $('#region-table').DataTable({
             ajax: {


### PR DESCRIPTION
## Summary
- add sample NUTS geojson file to static assets
- display map in group regions page with Leaflet
- clicking polygons updates hidden `regionai` field
- support multiple delimiters in `/group-regions/add`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686ae84398608324a4b984df6c1c5cc4