### PR TITLE
Extend region map to support PCODE

### DIFF
--- a/web_app/templates/group_regions.html
+++ b/web_app/templates/group_regions.html
@@ -42,13 +42,15 @@ $(document).ready(function() {
     function updateField(){
         $('#regionai').val(Array.from(selected).join(';'));
     }
-    fetch('/static/nuts_regions.geojson')
-        .then(r => r.json())
-        .then(data => {
-            L.geoJSON(data, {
-                onEachFeature: function(feature, layer){
-                    const code = feature.properties.NUTS_ID || feature.properties.id;
-                    if(!code) return;
+        fetch('/static/nuts_regions.geojson')
+            .then(r => r.json())
+            .then(data => {
+                L.geoJSON(data, {
+                    onEachFeature: function(feature, layer){
+                        const code = feature.properties.NUTS_ID ||
+                                     feature.properties.PCODE ||
+                                     feature.properties.id;
+                        if(!code) return;
                     layer.on('click', function(){
                         if(selected.has(code)){
                             selected.delete(code);


### PR DESCRIPTION
## Summary
- allow `group_regions` map to read region code from a `PCODE` field

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686aea1b9da08324993a9a473da6153e