### PR TITLE
Show region codes on map

### DIFF
--- a/web_app/static/style.css
+++ b/web_app/static/style.css
@@ -2,3 +2,9 @@ body { font-family: Arial, sans-serif; margin: 20px; }
 nav a { margin-right: 6px; }
 .page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1em; }
 .add-btn { padding: 4px 8px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 4px; }
+.region-label {
+    background: transparent;
+    border: none;
+    font-size: 10px;
+    font-weight: bold;
+}

--- a/web_app/templates/group_regions.html
+++ b/web_app/templates/group_regions.html
@@ -61,7 +61,7 @@ $(document).ready(function() {
                         }
                         updateField();
                     });
-                    layer.bindTooltip(code);
+                    layer.bindTooltip(code, {permanent: true, direction:'center', className:'region-label'});
                 },
                 style:{color:'#3388ff',weight:1,fillOpacity:0.4}
             }).addTo(map);


### PR DESCRIPTION
## Summary
- label NUTS regions with their code on the map
- add CSS styling for region labels

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_686af1e8ec9083248845691ffae8759e