### PR TITLE
Update group region map styling

### DIFF
--- a/web_app/static/style.css
+++ b/web_app/static/style.css
@@ -5,6 +5,8 @@ nav a { margin-right: 6px; }
 .region-label {
     background: transparent;
     border: none;
+    padding: 0;
+    box-shadow: none;
     font-size: 10px;
     font-weight: bold;
 }

--- a/web_app/templates/group_regions.html
+++ b/web_app/templates/group_regions.html
@@ -37,8 +37,9 @@ $(document).ready(function() {
     const map = L.map('map').setView([55.2, 23.9], 6);
     let geoLayer;
     function normalizeCode(code){
-        const m = code && code.match(/^([A-Z]{2})(\d{2})/);
-        return m ? m[1] + m[2] : code;
+        const m = code && code.match(/^([A-Z]{2})[^0-9]*([0-9]{2})/);
+        if(m) return m[1] + m[2];
+        return code.slice(0,4);
     }
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         maxZoom: 10,
@@ -61,16 +62,16 @@ $(document).ready(function() {
                     layer.on('click', function(){
                         if(selected.has(norm)){
                             selected.delete(norm);
-                            layer.setStyle({fillColor: '#3388ff'});
+                            layer.setStyle({fillColor: '#3388ff', fillOpacity:0});
                         } else {
                             selected.add(norm);
-                            layer.setStyle({fillColor: '#00ff00'});
+                            layer.setStyle({fillColor: '#00ff00', fillOpacity:0.5});
                         }
                         updateField();
                     });
                     layer.bindTooltip(norm, {permanent: true, direction:'center', className:'region-label'});
                 },
-                style:{color:'#3388ff',weight:1,fillOpacity:0.4}
+                style:{color:'#3388ff',weight:1,fillOpacity:0}
             }).addTo(map);
                 loadGroupRegions();
         });
@@ -105,9 +106,9 @@ function initTable(){
             const code = layer.code;
             if(!code) return;
             if(selected.has(code)){
-                layer.setStyle({fillColor:'#00ff00'});
+                layer.setStyle({fillColor:'#00ff00', fillOpacity:0.5});
             } else {
-                layer.setStyle({fillColor:'#3388ff'});
+                layer.setStyle({fillColor:'#3388ff', fillOpacity:0});
             }
         });
         updateField();


### PR DESCRIPTION
## Summary
- adjust `normalizeCode` to better format region labels
- display unselected regions with transparent fill
- show region labels without tooltip boxes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: httpx, bcrypt)*

------
https://chatgpt.com/codex/tasks/task_e_686b6d5eefd883248316722145497ab4