### PR TITLE
Update group region map to LAU codes

### DIFF
--- a/fastapi_app/tests/test_group_regions.py
+++ b/fastapi_app/tests/test_group_regions.py
@@ -1,4 +1,5 @@
 import os
+import re
 os.environ.setdefault("SECRET_KEY", "test-secret")
 from fastapi.testclient import TestClient
 from fastapi_app.app.main import app
@@ -74,6 +75,7 @@ def test_group_region_crud():
     assert r2.status_code == 200
     rid = r2.json()["id"]
     assert r2.json()["vadybininkas_id"] == emp.id
+    assert re.match(r"^[A-Z]{2}\d{2}$", r2.json()["region_code"]) is not None
 
     r3 = client.get(f"/{tenant.id}/groups/{gid}/regions", headers=headers)
     assert any(reg["id"] == rid and reg["vadybininkas_id"] == emp.id for reg in r3.json())
@@ -106,4 +108,4 @@ def test_group_regions_csv():
     header = r.text.splitlines()[0]
     assert "region_code" in header
     assert "vadybininkas_id" in header
-    assert "LT01" in r.text
+    assert re.search(r"LT\d{2}", r.text)

--- a/web_app/static/lau_regions.geojson
+++ b/web_app/static/lau_regions.geojson
@@ -1,0 +1,43 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "LAU_LABEL": "0101 Vilnius",
+        "COUNTRY": "LT"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [22.0, 55.0],
+            [23.0, 55.0],
+            [23.0, 56.0],
+            [22.0, 56.0],
+            [22.0, 55.0]
+          ]
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "LAU_LABEL": "0202 Kaunas",
+        "COUNTRY": "LT"
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [23.0, 55.0],
+            [24.0, 55.0],
+            [24.0, 56.0],
+            [23.0, 56.0],
+            [23.0, 55.0]
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/web_app/templates/group_regions.html
+++ b/web_app/templates/group_regions.html
@@ -36,10 +36,12 @@ $(document).ready(function() {
     const selected = new Set();
     const map = L.map('map').setView([55.2, 23.9], 6);
     let geoLayer;
-    function normalizeCode(code){
-        const m = code && code.match(/^([A-Z]{2})[^0-9]*([0-9]{2})/);
-        if(m) return m[1] + m[2];
-        return code.slice(0,4);
+    function normalizeCode(feature){
+        const country = feature.properties.COUNTRY || feature.properties.CNTR_CODE || '';
+        const label = feature.properties.LAU_LABEL || '';
+        const match = label.match(/(\d{2})/);
+        const digits = match ? match[1] : label.slice(0,2);
+        return country + digits;
     }
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         maxZoom: 10,
@@ -48,16 +50,12 @@ $(document).ready(function() {
     function updateField(){
         $('#regionai').val(Array.from(selected).join(';'));
     }
-        fetch('/static/LAU_RG_01M_2023_4326.geojson')
+        fetch('/static/lau_regions.geojson')
             .then(r => r.json())
             .then(data => {
                 geoLayer = L.geoJSON(data, {
                     onEachFeature: function(feature, layer){
-                        const code = feature.properties.NUTS_ID ||
-                                     feature.properties.PCODE ||
-                                     feature.properties.id;
-                        if(!code) return;
-                        const norm = normalizeCode(code);
+                        const norm = normalizeCode(feature);
                         layer.code = norm;
                     layer.on('click', function(){
                         if(selected.has(norm)){
@@ -101,7 +99,7 @@ function initTable(){
         if(!gid) return;
         const resp = await fetch('/api/group-regions?gid='+gid);
         const data = await resp.json();
-        data.data.forEach(r => selected.add(normalizeCode(r.regiono_kodas)));
+        data.data.forEach(r => selected.add(r.regiono_kodas));
         geoLayer.eachLayer(function(layer){
             const code = layer.code;
             if(!code) return;


### PR DESCRIPTION
## Summary
- add a sample `lau_regions.geojson` dataset with `LAU_LABEL` and `COUNTRY`
- load this file in the group region map
- compute codes from `LAU_LABEL` and country
- keep selected codes in normalized format
- test that region codes match expected LAU pattern

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686b827605548324b00d0eb1c915d1ba