### PR TITLE
Fix group region map file path

### DIFF
--- a/web_app/templates/group_regions.html
+++ b/web_app/templates/group_regions.html
@@ -50,7 +50,7 @@ $(document).ready(function() {
     function updateField(){
         $('#regionai').val(Array.from(selected).join(';'));
     }
-        fetch('/static/lau_regions.geojson')
+        fetch('/static/LAU_RG_01M_2023_4326.geojson')
             .then(r => r.json())
             .then(data => {
                 geoLayer = L.geoJSON(data, {


### PR DESCRIPTION
## Summary
- update the group_regions template to load the full LAU dataset instead of the placeholder file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686b8537ec6483249d66280ff4b02076