### PR TITLE
Fix region labels on map

### DIFF
--- a/web_app/static/style.css
+++ b/web_app/static/style.css
@@ -2,11 +2,11 @@ body { font-family: Arial, sans-serif; margin: 20px; }
 nav a { margin-right: 6px; }
 .page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 1em; }
 .add-btn { padding: 4px 8px; background-color: #4CAF50; color: white; text-decoration: none; border-radius: 4px; }
-.region-label {
-    background: transparent;
-    border: none;
-    padding: 0;
-    box-shadow: none;
+.leaflet-tooltip.region-label {
+    background: transparent !important;
+    border: none !important;
+    padding: 0 !important;
+    box-shadow: none !important;
     font-size: 10px;
     font-weight: bold;
 }


### PR DESCRIPTION
## Summary
- remove white background from region numbers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `fastapi`, `bcrypt`)*

------
https://chatgpt.com/codex/tasks/task_e_686ba56e3f9c8324a0ee9a54d9c42fc2