### PR TITLE
Show region borders on map

### DIFF
--- a/web_app/templates/group_regions.html
+++ b/web_app/templates/group_regions.html
@@ -64,18 +64,16 @@ $(document).ready(function() {
                     layer.on('click', function(){
                         if(selected.has(norm)){
                             selected.delete(norm);
-                            layer.setStyle({fillColor: '#3388ff', fillOpacity:0,
-                                            color:'transparent', weight:0});
+                            layer.setStyle({fillColor: '#3388ff', fillOpacity:0});
                         } else {
                             selected.add(norm);
-                            layer.setStyle({fillColor: '#00ff00', fillOpacity:0.5,
-                                            color:'transparent', weight:0});
+                            layer.setStyle({fillColor: '#00ff00', fillOpacity:0.5});
                         }
                         updateField();
                     });
                     layer.bindTooltip(norm, {permanent: true, direction:'center', className:'region-label'});
                 },
-                style:{color:'transparent',weight:0,fillOpacity:0}
+                style:{color:'#3388ff',weight:1,fillOpacity:0}
             }).addTo(map);
                 loadGroupRegions();
         });
@@ -110,11 +108,9 @@ function initTable(){
             const code = layer.code;
             if(!code) return;
             if(selected.has(code)){
-                layer.setStyle({fillColor:'#00ff00', fillOpacity:0.5,
-                                color:'transparent', weight:0});
+                layer.setStyle({fillColor:'#00ff00', fillOpacity:0.5});
             } else {
-                layer.setStyle({fillColor:'#3388ff', fillOpacity:0,
-                                color:'transparent', weight:0});
+                layer.setStyle({fillColor:'#3388ff', fillOpacity:0});
             }
         });
         updateField();


### PR DESCRIPTION
## Summary
- restore visible borders on group regions map

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686ba70858688324b9925b9b11978bee