### PR TITLE
Make group regions map square

### DIFF
--- a/web_app/templates/group_regions.html
+++ b/web_app/templates/group_regions.html
@@ -18,7 +18,7 @@
         </tr>
     </thead>
 </table>
-<div id="map" style="height:400px; margin-top:10px;"></div>
+<div id="map" style="height:400px; width:400px; margin-top:10px;"></div>
 <form id="add-form" style="margin-top:10px;">
     <input type="hidden" name="grupe_id" id="grupe-id-input">
     <label>Nauji regionai (pvz. FR10;DE20)</label>


### PR DESCRIPTION
## Summary
- style group regions map with equal height and width

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686ba866042c8324871ddb58df0d461f