### PR TITLE
Adjust group map style

### DIFF
--- a/web_app/templates/group_regions.html
+++ b/web_app/templates/group_regions.html
@@ -18,7 +18,7 @@
         </tr>
     </thead>
 </table>
-<div id="map" style="height:1200px; width:1200px; margin-top:10px;"></div>
+<div id="map" style="height:1200px; width:1600px; margin-top:10px;"></div>
 <form id="add-form" style="margin-top:10px;">
     <input type="hidden" name="grupe_id" id="grupe-id-input">
     <label>Nauji regionai (pvz. FR10;DE20)</label>
@@ -73,7 +73,7 @@ $(document).ready(function() {
                     });
                     layer.bindTooltip(norm, {permanent: true, direction:'center', className:'region-label'});
                 },
-                style:{color:'#3388ff',weight:1,fillOpacity:0}
+                style:{color:'red',weight:3,fillOpacity:0}
             }).addTo(map);
                 loadGroupRegions();
         });


### PR DESCRIPTION
## Summary
- expand group region map width to 1600px
- display country borders with thicker red lines

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686baab421748324b81a4a671f22c3b7