### PR TITLE
Add Git LFS tracking for geojson

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.geojson filter=lfs diff=lfs merge=lfs -text

--- a/web_app/static/LAU_RG_01M_2023_4326.geojson
+++ b/web_app/static/LAU_RG_01M_2023_4326.geojson
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2027742f42b9d4e87851b64c769b89d8af15a7a3334d907f7ad03b6c3969a84b
+size 799


### PR DESCRIPTION
## Summary
- initialize git LFS and start tracking `*.geojson`
- add new LAU region geojson file stored with LFS

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `git lfs push origin HEAD` *(fails: Invalid remote name)*

------
https://chatgpt.com/codex/tasks/task_e_686bb3d1f060832499d48714433e4692