### PR TITLE
Update region map to use simplified data

### DIFF
--- a/web_app/templates/group_regions.html
+++ b/web_app/templates/group_regions.html
@@ -37,6 +37,9 @@ $(document).ready(function() {
     const map = L.map('map').setView([55.2, 23.9], 6);
     let geoLayer;
     function normalizeCode(feature){
+        if(feature.properties.region_code){
+            return feature.properties.region_code;
+        }
         if (feature.properties.NUTS_ID) {
             const match = feature.properties.NUTS_ID.match(/^([A-Z]{2})(\d{2})/);
             return match ? match[1] + match[2] : feature.properties.NUTS_ID;
@@ -54,7 +57,7 @@ $(document).ready(function() {
     function updateField(){
         $('#regionai').val(Array.from(selected).join(';'));
     }
-        fetch('/static/nuts_regions.geojson')
+        fetch('/static/simplified_regions.geojson')
             .then(r => r.json())
             .then(data => {
                 geoLayer = L.geoJSON(data, {


### PR DESCRIPTION
## Summary
- switch group regions map data file to `simplified_regions.geojson`
- show `region_code` in tooltips by enhancing the `normalizeCode` helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686bb607ce148324989fe310d03aa763