### PR TITLE
Fix start scripts for missing pyvenv.cfg

### DIFF
--- a/start_work2_server.bat
+++ b/start_work2_server.bat
@@ -1,7 +1,11 @@
 @echo off
 cd /d %~dp0
 
-if not exist venv (
+rem Create virtual environment if missing or broken
+if not exist venv\pyvenv.cfg (
+    if exist venv (
+        rmdir /s /q venv
+    )
     python -m venv venv
     call venv\Scripts\python.exe -m pip install --upgrade pip
     call venv\Scripts\python.exe -m pip install -r requirements.txt

--- a/start_work2_server.sh
+++ b/start_work2_server.sh
@@ -2,7 +2,8 @@
 set -e
 cd "$(dirname "$0")"
 
-if [ ! -d venv ]; then
+if [ ! -f venv/pyvenv.cfg ]; then
+    rm -rf venv
     python3 -m venv venv
     ./venv/bin/pip install --upgrade pip
     ./venv/bin/pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- improve `start_work2_server.bat` to recreate the virtualenv when `pyvenv.cfg` is missing
- update `start_work2_server.sh` with the same check

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686bc4dc4744832489ddc5b90edeb230