### PR TITLE
Fix corrupted LAU GeoJSON

### DIFF
--- a/web_app/static/simplified_lau_europe_limited_labeled.geojson
+++ b/web_app/static/simplified_lau_europe_limited_labeled.geojson
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8c9e66a672b185c294d4f2bce41bde9a766ecfd60c488b023ef1bf42f70fe410
-size 21526185
+oid sha256:5bc4c9dea265486d94efa860f87258c46637cc0651a90308d16463a6d5823337
+size 21525982


### PR DESCRIPTION
## Summary
- revert merge conflict markers in `simplified_lau_europe_limited_labeled.geojson`
- restore valid GeoJSON data from Git LFS

## Testing
- `make test` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_e_686d9066c1f88324a0ad7b52f3dc0085