### PR TITLE
Add NUTS regions layer

### DIFF
--- a/web_app/templates/group_regions.html
+++ b/web_app/templates/group_regions.html
@@ -62,6 +62,7 @@ $(document).ready(function() {
     }
 
 
+        let nutsLayer;
         fetch('/static/simplified_lau_europe_limited_labeled.geojson')
             .then(response => {
                 if (!response.ok) {
@@ -89,10 +90,23 @@ $(document).ready(function() {
                             updateField();
                         });
                         const label = feature.properties.label || 'Nėra kodo';
-                        layer.bindTooltip(label, { permanent: false, direction: 'top' });
+                        layer.bindTooltip(label, { permanent: false, direction: 'top', className: 'region-label' });
                     },
                     style:{ color:'#3388ff', weight:1, fillOpacity:0.2 }
                 }).addTo(map);
+                fetch('/static/nuts_regions.geojson')
+                    .then(r => r.json())
+                    .then(nuts => {
+                        nutsLayer = L.geoJSON(nuts, {
+                            onEachFeature: function(feature, layer){
+                                const code = feature.properties.NUTS_ID;
+                                if(code){
+                                    layer.bindTooltip(code, { permanent: true, direction: 'center', className: 'region-label' });
+                                }
+                            },
+                            style:{ color:'#ff0000', weight:2, fillOpacity:0 }
+                        }).addTo(map);
+                    });
                 map.fitBounds(geoLayer.getBounds());
                 loadGroupRegions();
             })


### PR DESCRIPTION
## Summary
- show region codes without tooltip rectangles
- overlay NUTS regions on the map

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686ed3869f9083248f5a57633c73fdbf