### PR TITLE
Filter NUTS map to level 2

### DIFF
--- a/web_app/templates/group_regions.html
+++ b/web_app/templates/group_regions.html
@@ -74,7 +74,11 @@ $(document).ready(function() {
                     console.error('Klaida įkeliant regionų failą: tuščias GeoJSON');
                     return;
                 }
-                geoLayer = L.geoJSON(geojson, {
+                const nuts2 = {
+                    ...geojson,
+                    features: geojson.features.filter(f => f.properties.LEVL_CODE === 2)
+                };
+                geoLayer = L.geoJSON(nuts2, {
                     onEachFeature: function(feature, layer){
                         const norm = normalizeCode(feature);
                         layer.code = norm;


### PR DESCRIPTION
## Summary
- filter GeoJSON features so the group regions map shows only NUTS2 polygons

## Testing
- `make test` *(fails: Could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686ee640b1d88324af7da825e8fbdb1a