### PR TITLE
Fix map region labels

### DIFF
--- a/web_app/templates/group_regions.html
+++ b/web_app/templates/group_regions.html
@@ -92,7 +92,11 @@ $(document).ready(function() {
                             }
                             updateField();
                         });
-                        const label = feature.properties.label || 'Nėra kodo';
+                        const label =
+                            feature.properties.NUTS_ID ||
+                            feature.properties.NUTS_NAME ||
+                            feature.properties.label ||
+                            'Nėra kodo';
                         layer.bindTooltip(label, { permanent: false, direction: 'top', className: 'region-label' });
                     },
                     style:{ color:'#3388ff', weight:1, fillOpacity:0.2 }


### PR DESCRIPTION
## Summary
- fix region tooltip label fallback in group regions map

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*
- `make test` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_e_686ee7dc4d9c8324b89c2141eaaf1dcc