### PR TITLE
Fix LAU dataset path

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,12 @@ alembic -c fastapi_app/alembic.ini revision --autogenerate -m "message"
 ```
 ## LAU dataset
 
-The `scripts/simplify_lau.py` script uses the file `web_app/static/LAU_RG_01M_2023_4326.geojson` as input.
+The `scripts/simplify_lau.py` script uses the file `web_app/static/LAU_RG_01M_2023_3035.geojson` as input.
 This GeoJSON is not included in the repository due to its size.
 You can download it from the European Commission GISCO service:
 
 ```bash
-wget https://gisco-services.ec.europa.eu/distribution/v2/lau/geojson/LAU_RG_01M_2023_4326.geojson -O web_app/static/LAU_RG_01M_2023_4326.geojson
+wget https://gisco-services.ec.europa.eu/distribution/v2/lau/geojson/LAU_RG_01M_2023_3035.geojson -O web_app/static/LAU_RG_01M_2023_3035.geojson
 ```
 
 After downloading run `python scripts/simplify_lau.py` to create `web_app/static/simplified_regions.geojson`.

--- a/scripts/simplify_lau.py
+++ b/scripts/simplify_lau.py
@@ -1,6 +1,8 @@
 import geopandas as gpd
 
-INPUT_PATH = "web_app/static/LAU_RG_01M_2023_4326.geojson"
+# The LAU dataset is stored in EPSG:3035 to match the original
+# distribution from the European Commission GISCO service.
+INPUT_PATH = "web_app/static/LAU_RG_01M_2023_3035.geojson"
 OUTPUT_PATH = "web_app/static/simplified_regions.geojson"
 
 


### PR DESCRIPTION
## Summary
- use the LAU dataset in EPSG:3035
- document the correct dataset name and download URL

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686efbc711bc8324931e61f2161f9124